### PR TITLE
fix(mask4): fix x86 issues with maskq 

### DIFF
--- a/includes/rtm/mask4q.h
+++ b/includes/rtm/mask4q.h
@@ -49,12 +49,7 @@ namespace rtm
 	inline uint64_t RTM_SIMD_CALL mask_get_x(const mask4q& input) RTM_NO_EXCEPT
 	{
 #if defined(RTM_SSE2_INTRINSICS)
-#if defined(_M_X64)
 		return _mm_cvtsi128_si64(_mm_castpd_si128(input.xy));
-#else
-		// Just sign extend on 32bit systems
-		return (uint64_t)_mm_cvtsi128_si32(_mm_castpd_si128(input.xy));
-#endif
 #else
 		return input.x;
 #endif
@@ -66,12 +61,7 @@ namespace rtm
 	inline uint64_t RTM_SIMD_CALL mask_get_y(const mask4q& input) RTM_NO_EXCEPT
 	{
 #if defined(RTM_SSE2_INTRINSICS)
-#if defined(_M_X64)
 		return _mm_cvtsi128_si64(_mm_castpd_si128(_mm_shuffle_pd(input.xy, input.xy, 1)));
-#else
-		// Just sign extend on 32bit systems
-		return (uint64_t)_mm_cvtsi128_si32(_mm_castpd_si128(_mm_shuffle_pd(input.xy, input.xy, 1)));
-#endif
 #else
 		return input.y;
 #endif
@@ -83,12 +73,7 @@ namespace rtm
 	inline uint64_t RTM_SIMD_CALL mask_get_z(const mask4q& input) RTM_NO_EXCEPT
 	{
 #if defined(RTM_SSE2_INTRINSICS)
-#if defined(_M_X64)
 		return _mm_cvtsi128_si64(_mm_castpd_si128(input.zw));
-#else
-		// Just sign extend on 32bit systems
-		return (uint64_t)_mm_cvtsi128_si32(_mm_castpd_si128(input.zw));
-#endif
 #else
 		return input.z;
 #endif
@@ -100,12 +85,7 @@ namespace rtm
 	inline uint64_t RTM_SIMD_CALL mask_get_w(const mask4q& input) RTM_NO_EXCEPT
 	{
 #if defined(RTM_SSE2_INTRINSICS)
-#if defined(_M_X64)
 		return _mm_cvtsi128_si64(_mm_castpd_si128(_mm_shuffle_pd(input.zw, input.zw, 1)));
-#else
-		// Just sign extend on 32bit systems
-		return (uint64_t)_mm_cvtsi128_si32(_mm_castpd_si128(_mm_shuffle_pd(input.zw, input.zw, 1)));
-#endif
 #else
 		return input.w;
 #endif

--- a/tests/sources/test_mask4.cpp
+++ b/tests/sources/test_mask4.cpp
@@ -46,7 +46,7 @@ TEST_CASE("mask4i math", "[math][mask]")
 	test_mask_impl<uint32_t>();
 }
 
-TEST_CASE("mask4d math", "[math][mask]")
+TEST_CASE("mask4q math", "[math][mask]")
 {
 	test_mask_impl<uint64_t>();
 }


### PR DESCRIPTION
VS2019 x86 release build has issues with the old code. I can't recall why it was done like that in the first place but there doesn't appear to be a valid reason for it and it keeps things simpler.