### PR TITLE
chore: restore separate mix tests for faster compilation

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,12 +2,25 @@ version: 1.0.0.{build}
 
 environment:
   PYTHON: "C:\\Python33-x64"
-  VISUAL_STUDIO: "C:\\Program Files (x86)\\Microsoft Visual Studio"
 
 image:
 - Visual Studio 2015
 - Visual Studio 2017
 - Visual Studio 2019
+
+configuration:
+  - Debug
+  - Release
+
+platform:
+  - x86
+  - x64
+  - arm64
+
+matrix:
+  exclude:
+    - image: Visual Studio 2015
+      platform: arm64
 
 install:
 - cmd: >-
@@ -17,26 +30,14 @@ build_script:
 - cmd: >-
     IF "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2015" (SET COMPILER=vs2015)
 
-    IF "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2017" (SET COMPILER=vs2017 && SET ARM64_SUPPORTED=1)
+    IF "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2017" (SET COMPILER=vs2017)
 
-    IF "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2019" (SET COMPILER=vs2019 && SET ARM64_SUPPORTED=1)
+    IF "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2019" (SET COMPILER=vs2019)
 
-    IF "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2019" "%VISUAL_STUDIO%\\Installer\\vs_installershell.exe" modify --productId Microsoft.VisualStudio.Product.Community --channelId VisualStudio.16.Release --add Microsoft.VisualStudio.Component.VC.Tools.ARM64 --add Microsoft.VisualStudio.Component.VC.Runtimes.ARM64.Spectre --quiet
+    SET UNIT_TEST_FLAG=-unit_test
 
-    %PYTHON%\\python.exe make.py -clean -build -unit_test -compiler %COMPILER% -config Debug -cpu x86
+    IF "%platform%"=="arm64" (SET "UNIT_TEST_FLAG= ")
 
-    %PYTHON%\\python.exe make.py -clean -build -unit_test -compiler %COMPILER% -config Release -cpu x86
+    %PYTHON%\\python.exe make.py -build %UNIT_TEST_FLAG% -compiler %COMPILER% -config %configuration% -cpu %platform% -clean
 
-    %PYTHON%\\python.exe make.py -clean -build -unit_test -compiler %COMPILER% -config Release -cpu x86 -nosimd
-
-    %PYTHON%\\python.exe make.py -clean -build -unit_test -compiler %COMPILER% -config Debug -cpu x64
-
-    %PYTHON%\\python.exe make.py -clean -build -unit_test -compiler %COMPILER% -config Release -cpu x64
-
-    %PYTHON%\\python.exe make.py -clean -build -unit_test -compiler %COMPILER% -config Release -cpu x64 -nosimd
-
-    IF DEFINED ARM64_SUPPORTED %PYTHON%\\python.exe make.py -clean -build -compiler %COMPILER% -config Debug -cpu arm64
-
-    IF DEFINED ARM64_SUPPORTED %PYTHON%\\python.exe make.py -clean -build -compiler %COMPILER% -config Release -cpu arm64
-
-    IF DEFINED ARM64_SUPPORTED %PYTHON%\\python.exe make.py -clean -build -compiler %COMPILER% -config Release -cpu arm64 -nosimd
+    %PYTHON%\\python.exe make.py -build %UNIT_TEST_FLAG% -compiler %COMPILER% -config %configuration% -cpu %platform% -nosimd

--- a/tests/sources/test_vector4_impl.h
+++ b/tests/sources/test_vector4_impl.h
@@ -629,7 +629,7 @@ void test_vector4_impl(const FloatType threshold)
 	REQUIRE(vector_get_w(vector_sign(test_value0)) == scalar_sign(test_value0_flt[3]));
 }
 
-template<typename Vector4Type, typename FloatType>
+template<typename Vector4Type, typename FloatType, mix4 XArg>
 void test_vector_mix_impl(const FloatType threshold)
 {
 	const FloatType test_value0_flt[4] = { FloatType(2.0), FloatType(9.34), FloatType(-54.12), FloatType(6000.0) };
@@ -638,7 +638,7 @@ void test_vector_mix_impl(const FloatType threshold)
 	const Vector4Type test_value0 = vector_set(test_value0_flt[0], test_value0_flt[1], test_value0_flt[2], test_value0_flt[3]);
 	const Vector4Type test_value1 = vector_set(test_value1_flt[0], test_value1_flt[1], test_value1_flt[2], test_value1_flt[3]);
 
-	Vector4Type results[8 * 8 * 8 * 8];
+	Vector4Type results[8 * 8 * 8];
 	uint32_t index = 0;
 
 #define RTM_TEST_MIX_XYZ(comp0, comp1, comp2) \
@@ -671,35 +671,28 @@ void test_vector_mix_impl(const FloatType threshold)
 	RTM_TEST_MIX_XY(comp0, mix4::c); \
 	RTM_TEST_MIX_XY(comp0, mix4::d)
 
-	// This generates 8*8*8*8 = 4096 unit tests... it takes a while to compile and uses a lot of stack space
-	RTM_TEST_MIX_X(mix4::x);
-	RTM_TEST_MIX_X(mix4::y);
-	RTM_TEST_MIX_X(mix4::z);
-	RTM_TEST_MIX_X(mix4::w);
-	RTM_TEST_MIX_X(mix4::a);
-	RTM_TEST_MIX_X(mix4::b);
-	RTM_TEST_MIX_X(mix4::c);
-	RTM_TEST_MIX_X(mix4::d);
+	// This generates 8*8*8 = 512 unit tests... it takes a while to compile and uses a lot of stack space
+	RTM_TEST_MIX_X(XArg);
 
 	index = 0;
 
-	for (int comp0 = 0; comp0 < 8; ++comp0)
-		for (int comp1 = 0; comp1 < 8; ++comp1)
-			for (int comp2 = 0; comp2 < 8; ++comp2)
-				for (int comp3 = 0; comp3 < 8; ++comp3)
-				{
-					INFO("vector_mix<" << comp0 << ", " << comp1 << ", " << comp2 << ", " << comp3 << ">");
+	const int comp0 = (int)XArg;
+	for (int comp1 = 0; comp1 < 8; ++comp1)
+		for (int comp2 = 0; comp2 < 8; ++comp2)
+			for (int comp3 = 0; comp3 < 8; ++comp3)
+			{
+				INFO("vector_mix<" << comp0 << ", " << comp1 << ", " << comp2 << ", " << comp3 << ">");
 
-					const Vector4Type expected = vector_set(
-						rtm_impl::is_mix_xyzw((mix4)comp0) ? test_value0_flt[comp0 - (int)mix4::x] : test_value1_flt[comp0 - (int)mix4::a],
-						rtm_impl::is_mix_xyzw((mix4)comp1) ? test_value0_flt[comp1 - (int)mix4::x] : test_value1_flt[comp1 - (int)mix4::a],
-						rtm_impl::is_mix_xyzw((mix4)comp2) ? test_value0_flt[comp2 - (int)mix4::x] : test_value1_flt[comp2 - (int)mix4::a],
-						rtm_impl::is_mix_xyzw((mix4)comp3) ? test_value0_flt[comp3 - (int)mix4::x] : test_value1_flt[comp3 - (int)mix4::a]);
+				const Vector4Type expected = vector_set(
+					rtm_impl::is_mix_xyzw((mix4)comp0) ? test_value0_flt[comp0 - (int)mix4::x] : test_value1_flt[comp0 - (int)mix4::a],
+					rtm_impl::is_mix_xyzw((mix4)comp1) ? test_value0_flt[comp1 - (int)mix4::x] : test_value1_flt[comp1 - (int)mix4::a],
+					rtm_impl::is_mix_xyzw((mix4)comp2) ? test_value0_flt[comp2 - (int)mix4::x] : test_value1_flt[comp2 - (int)mix4::a],
+					rtm_impl::is_mix_xyzw((mix4)comp3) ? test_value0_flt[comp3 - (int)mix4::x] : test_value1_flt[comp3 - (int)mix4::a]);
 
-					REQUIRE(vector_all_near_equal(results[index], expected, threshold));
+				REQUIRE(vector_all_near_equal(expected, results[index], threshold));
 
-					++index;
-				}
+				++index;
+			}
 
 #undef RTM_TEST_MIX_X
 #undef RTM_TEST_MIX_XY

--- a/tests/sources/test_vector4d.cpp
+++ b/tests/sources/test_vector4d.cpp
@@ -36,8 +36,3 @@ TEST_CASE("vector4d math", "[math][vector4]")
 	REQUIRE(scalar_near_equal(vector_get_z(dst), 0.68123521f, 1.0e-6f));
 	REQUIRE(scalar_near_equal(vector_get_w(dst), -5.9182f, 1.0e-6f));
 }
-
-TEST_CASE("vector4d vector_mix", "[math][vector4]")
-{
-	test_vector_mix_impl<vector4d, double>(1.0e-9);
-}

--- a/tests/sources/test_vector4d_mix_a.cpp
+++ b/tests/sources/test_vector4d_mix_a.cpp
@@ -25,20 +25,7 @@
 
 #include "test_vector4_impl.h"
 
-TEST_CASE("vector4f math", "[math][vector4]")
+TEST_CASE("vector4d vector_mix<a * * *>", "[math][vector4]")
 {
-#if defined(RTM_NO_INTRINSICS)
-	const float threshold = 1.0e-4f;
-#else
-	const float threshold = 1.0e-5f;
-#endif
-
-	test_vector4_impl<float>(threshold);
-
-	const vector4f src = vector_set(-2.65f, 2.996113f, 0.68123521f, -5.9182f);
-	const vector4d dst = vector_cast(src);
-	REQUIRE(scalar_near_equal(vector_get_x(dst), -2.65, 1.0e-6));
-	REQUIRE(scalar_near_equal(vector_get_y(dst), 2.996113, 1.0e-6));
-	REQUIRE(scalar_near_equal(vector_get_z(dst), 0.68123521, 1.0e-6));
-	REQUIRE(scalar_near_equal(vector_get_w(dst), -5.9182, 1.0e-6));
+	test_vector_mix_impl<vector4d, double, mix4::a>(1.0e-9);
 }

--- a/tests/sources/test_vector4d_mix_b.cpp
+++ b/tests/sources/test_vector4d_mix_b.cpp
@@ -25,20 +25,7 @@
 
 #include "test_vector4_impl.h"
 
-TEST_CASE("vector4f math", "[math][vector4]")
+TEST_CASE("vector4d vector_mix<b * * *>", "[math][vector4]")
 {
-#if defined(RTM_NO_INTRINSICS)
-	const float threshold = 1.0e-4f;
-#else
-	const float threshold = 1.0e-5f;
-#endif
-
-	test_vector4_impl<float>(threshold);
-
-	const vector4f src = vector_set(-2.65f, 2.996113f, 0.68123521f, -5.9182f);
-	const vector4d dst = vector_cast(src);
-	REQUIRE(scalar_near_equal(vector_get_x(dst), -2.65, 1.0e-6));
-	REQUIRE(scalar_near_equal(vector_get_y(dst), 2.996113, 1.0e-6));
-	REQUIRE(scalar_near_equal(vector_get_z(dst), 0.68123521, 1.0e-6));
-	REQUIRE(scalar_near_equal(vector_get_w(dst), -5.9182, 1.0e-6));
+	test_vector_mix_impl<vector4d, double, mix4::b>(1.0e-9);
 }

--- a/tests/sources/test_vector4d_mix_c.cpp
+++ b/tests/sources/test_vector4d_mix_c.cpp
@@ -25,20 +25,7 @@
 
 #include "test_vector4_impl.h"
 
-TEST_CASE("vector4f math", "[math][vector4]")
+TEST_CASE("vector4d vector_mix<c * * *>", "[math][vector4]")
 {
-#if defined(RTM_NO_INTRINSICS)
-	const float threshold = 1.0e-4f;
-#else
-	const float threshold = 1.0e-5f;
-#endif
-
-	test_vector4_impl<float>(threshold);
-
-	const vector4f src = vector_set(-2.65f, 2.996113f, 0.68123521f, -5.9182f);
-	const vector4d dst = vector_cast(src);
-	REQUIRE(scalar_near_equal(vector_get_x(dst), -2.65, 1.0e-6));
-	REQUIRE(scalar_near_equal(vector_get_y(dst), 2.996113, 1.0e-6));
-	REQUIRE(scalar_near_equal(vector_get_z(dst), 0.68123521, 1.0e-6));
-	REQUIRE(scalar_near_equal(vector_get_w(dst), -5.9182, 1.0e-6));
+	test_vector_mix_impl<vector4d, double, mix4::c>(1.0e-9);
 }

--- a/tests/sources/test_vector4d_mix_d.cpp
+++ b/tests/sources/test_vector4d_mix_d.cpp
@@ -25,20 +25,7 @@
 
 #include "test_vector4_impl.h"
 
-TEST_CASE("vector4f math", "[math][vector4]")
+TEST_CASE("vector4d vector_mix<d * * *>", "[math][vector4]")
 {
-#if defined(RTM_NO_INTRINSICS)
-	const float threshold = 1.0e-4f;
-#else
-	const float threshold = 1.0e-5f;
-#endif
-
-	test_vector4_impl<float>(threshold);
-
-	const vector4f src = vector_set(-2.65f, 2.996113f, 0.68123521f, -5.9182f);
-	const vector4d dst = vector_cast(src);
-	REQUIRE(scalar_near_equal(vector_get_x(dst), -2.65, 1.0e-6));
-	REQUIRE(scalar_near_equal(vector_get_y(dst), 2.996113, 1.0e-6));
-	REQUIRE(scalar_near_equal(vector_get_z(dst), 0.68123521, 1.0e-6));
-	REQUIRE(scalar_near_equal(vector_get_w(dst), -5.9182, 1.0e-6));
+	test_vector_mix_impl<vector4d, double, mix4::d>(1.0e-9);
 }

--- a/tests/sources/test_vector4d_mix_w.cpp
+++ b/tests/sources/test_vector4d_mix_w.cpp
@@ -25,20 +25,7 @@
 
 #include "test_vector4_impl.h"
 
-TEST_CASE("vector4f math", "[math][vector4]")
+TEST_CASE("vector4d vector_mix<w * * *>", "[math][vector4]")
 {
-#if defined(RTM_NO_INTRINSICS)
-	const float threshold = 1.0e-4f;
-#else
-	const float threshold = 1.0e-5f;
-#endif
-
-	test_vector4_impl<float>(threshold);
-
-	const vector4f src = vector_set(-2.65f, 2.996113f, 0.68123521f, -5.9182f);
-	const vector4d dst = vector_cast(src);
-	REQUIRE(scalar_near_equal(vector_get_x(dst), -2.65, 1.0e-6));
-	REQUIRE(scalar_near_equal(vector_get_y(dst), 2.996113, 1.0e-6));
-	REQUIRE(scalar_near_equal(vector_get_z(dst), 0.68123521, 1.0e-6));
-	REQUIRE(scalar_near_equal(vector_get_w(dst), -5.9182, 1.0e-6));
+	test_vector_mix_impl<vector4d, double, mix4::w>(1.0e-9);
 }

--- a/tests/sources/test_vector4d_mix_x.cpp
+++ b/tests/sources/test_vector4d_mix_x.cpp
@@ -25,20 +25,7 @@
 
 #include "test_vector4_impl.h"
 
-TEST_CASE("vector4f math", "[math][vector4]")
+TEST_CASE("vector4d vector_mix<x * * *>", "[math][vector4]")
 {
-#if defined(RTM_NO_INTRINSICS)
-	const float threshold = 1.0e-4f;
-#else
-	const float threshold = 1.0e-5f;
-#endif
-
-	test_vector4_impl<float>(threshold);
-
-	const vector4f src = vector_set(-2.65f, 2.996113f, 0.68123521f, -5.9182f);
-	const vector4d dst = vector_cast(src);
-	REQUIRE(scalar_near_equal(vector_get_x(dst), -2.65, 1.0e-6));
-	REQUIRE(scalar_near_equal(vector_get_y(dst), 2.996113, 1.0e-6));
-	REQUIRE(scalar_near_equal(vector_get_z(dst), 0.68123521, 1.0e-6));
-	REQUIRE(scalar_near_equal(vector_get_w(dst), -5.9182, 1.0e-6));
+	test_vector_mix_impl<vector4d, double, mix4::x>(1.0e-9);
 }

--- a/tests/sources/test_vector4d_mix_y.cpp
+++ b/tests/sources/test_vector4d_mix_y.cpp
@@ -25,20 +25,7 @@
 
 #include "test_vector4_impl.h"
 
-TEST_CASE("vector4f math", "[math][vector4]")
+TEST_CASE("vector4d vector_mix<y * * *>", "[math][vector4]")
 {
-#if defined(RTM_NO_INTRINSICS)
-	const float threshold = 1.0e-4f;
-#else
-	const float threshold = 1.0e-5f;
-#endif
-
-	test_vector4_impl<float>(threshold);
-
-	const vector4f src = vector_set(-2.65f, 2.996113f, 0.68123521f, -5.9182f);
-	const vector4d dst = vector_cast(src);
-	REQUIRE(scalar_near_equal(vector_get_x(dst), -2.65, 1.0e-6));
-	REQUIRE(scalar_near_equal(vector_get_y(dst), 2.996113, 1.0e-6));
-	REQUIRE(scalar_near_equal(vector_get_z(dst), 0.68123521, 1.0e-6));
-	REQUIRE(scalar_near_equal(vector_get_w(dst), -5.9182, 1.0e-6));
+	test_vector_mix_impl<vector4d, double, mix4::y>(1.0e-9);
 }

--- a/tests/sources/test_vector4d_mix_z.cpp
+++ b/tests/sources/test_vector4d_mix_z.cpp
@@ -25,20 +25,7 @@
 
 #include "test_vector4_impl.h"
 
-TEST_CASE("vector4f math", "[math][vector4]")
+TEST_CASE("vector4d vector_mix<z * * *>", "[math][vector4]")
 {
-#if defined(RTM_NO_INTRINSICS)
-	const float threshold = 1.0e-4f;
-#else
-	const float threshold = 1.0e-5f;
-#endif
-
-	test_vector4_impl<float>(threshold);
-
-	const vector4f src = vector_set(-2.65f, 2.996113f, 0.68123521f, -5.9182f);
-	const vector4d dst = vector_cast(src);
-	REQUIRE(scalar_near_equal(vector_get_x(dst), -2.65, 1.0e-6));
-	REQUIRE(scalar_near_equal(vector_get_y(dst), 2.996113, 1.0e-6));
-	REQUIRE(scalar_near_equal(vector_get_z(dst), 0.68123521, 1.0e-6));
-	REQUIRE(scalar_near_equal(vector_get_w(dst), -5.9182, 1.0e-6));
+	test_vector_mix_impl<vector4d, double, mix4::z>(1.0e-9);
 }

--- a/tests/sources/test_vector4f_mix_a.cpp
+++ b/tests/sources/test_vector4f_mix_a.cpp
@@ -25,20 +25,7 @@
 
 #include "test_vector4_impl.h"
 
-TEST_CASE("vector4f math", "[math][vector4]")
+TEST_CASE("vector4f vector_mix<a * * *>", "[math][vector4]")
 {
-#if defined(RTM_NO_INTRINSICS)
-	const float threshold = 1.0e-4f;
-#else
-	const float threshold = 1.0e-5f;
-#endif
-
-	test_vector4_impl<float>(threshold);
-
-	const vector4f src = vector_set(-2.65f, 2.996113f, 0.68123521f, -5.9182f);
-	const vector4d dst = vector_cast(src);
-	REQUIRE(scalar_near_equal(vector_get_x(dst), -2.65, 1.0e-6));
-	REQUIRE(scalar_near_equal(vector_get_y(dst), 2.996113, 1.0e-6));
-	REQUIRE(scalar_near_equal(vector_get_z(dst), 0.68123521, 1.0e-6));
-	REQUIRE(scalar_near_equal(vector_get_w(dst), -5.9182, 1.0e-6));
+	test_vector_mix_impl<vector4f, float, mix4::a>(1.0e-6f);
 }

--- a/tests/sources/test_vector4f_mix_b.cpp
+++ b/tests/sources/test_vector4f_mix_b.cpp
@@ -25,20 +25,7 @@
 
 #include "test_vector4_impl.h"
 
-TEST_CASE("vector4f math", "[math][vector4]")
+TEST_CASE("vector4f vector_mix<b * * *>", "[math][vector4]")
 {
-#if defined(RTM_NO_INTRINSICS)
-	const float threshold = 1.0e-4f;
-#else
-	const float threshold = 1.0e-5f;
-#endif
-
-	test_vector4_impl<float>(threshold);
-
-	const vector4f src = vector_set(-2.65f, 2.996113f, 0.68123521f, -5.9182f);
-	const vector4d dst = vector_cast(src);
-	REQUIRE(scalar_near_equal(vector_get_x(dst), -2.65, 1.0e-6));
-	REQUIRE(scalar_near_equal(vector_get_y(dst), 2.996113, 1.0e-6));
-	REQUIRE(scalar_near_equal(vector_get_z(dst), 0.68123521, 1.0e-6));
-	REQUIRE(scalar_near_equal(vector_get_w(dst), -5.9182, 1.0e-6));
+	test_vector_mix_impl<vector4f, float, mix4::b>(1.0e-6f);
 }

--- a/tests/sources/test_vector4f_mix_c.cpp
+++ b/tests/sources/test_vector4f_mix_c.cpp
@@ -25,20 +25,7 @@
 
 #include "test_vector4_impl.h"
 
-TEST_CASE("vector4f math", "[math][vector4]")
+TEST_CASE("vector4f vector_mix<c * * *>", "[math][vector4]")
 {
-#if defined(RTM_NO_INTRINSICS)
-	const float threshold = 1.0e-4f;
-#else
-	const float threshold = 1.0e-5f;
-#endif
-
-	test_vector4_impl<float>(threshold);
-
-	const vector4f src = vector_set(-2.65f, 2.996113f, 0.68123521f, -5.9182f);
-	const vector4d dst = vector_cast(src);
-	REQUIRE(scalar_near_equal(vector_get_x(dst), -2.65, 1.0e-6));
-	REQUIRE(scalar_near_equal(vector_get_y(dst), 2.996113, 1.0e-6));
-	REQUIRE(scalar_near_equal(vector_get_z(dst), 0.68123521, 1.0e-6));
-	REQUIRE(scalar_near_equal(vector_get_w(dst), -5.9182, 1.0e-6));
+	test_vector_mix_impl<vector4f, float, mix4::c>(1.0e-6f);
 }

--- a/tests/sources/test_vector4f_mix_d.cpp
+++ b/tests/sources/test_vector4f_mix_d.cpp
@@ -25,20 +25,7 @@
 
 #include "test_vector4_impl.h"
 
-TEST_CASE("vector4f math", "[math][vector4]")
+TEST_CASE("vector4f vector_mix<d * * *>", "[math][vector4]")
 {
-#if defined(RTM_NO_INTRINSICS)
-	const float threshold = 1.0e-4f;
-#else
-	const float threshold = 1.0e-5f;
-#endif
-
-	test_vector4_impl<float>(threshold);
-
-	const vector4f src = vector_set(-2.65f, 2.996113f, 0.68123521f, -5.9182f);
-	const vector4d dst = vector_cast(src);
-	REQUIRE(scalar_near_equal(vector_get_x(dst), -2.65, 1.0e-6));
-	REQUIRE(scalar_near_equal(vector_get_y(dst), 2.996113, 1.0e-6));
-	REQUIRE(scalar_near_equal(vector_get_z(dst), 0.68123521, 1.0e-6));
-	REQUIRE(scalar_near_equal(vector_get_w(dst), -5.9182, 1.0e-6));
+	test_vector_mix_impl<vector4f, float, mix4::d>(1.0e-6f);
 }

--- a/tests/sources/test_vector4f_mix_w.cpp
+++ b/tests/sources/test_vector4f_mix_w.cpp
@@ -25,20 +25,7 @@
 
 #include "test_vector4_impl.h"
 
-TEST_CASE("vector4f math", "[math][vector4]")
+TEST_CASE("vector4f vector_mix<w * * *>", "[math][vector4]")
 {
-#if defined(RTM_NO_INTRINSICS)
-	const float threshold = 1.0e-4f;
-#else
-	const float threshold = 1.0e-5f;
-#endif
-
-	test_vector4_impl<float>(threshold);
-
-	const vector4f src = vector_set(-2.65f, 2.996113f, 0.68123521f, -5.9182f);
-	const vector4d dst = vector_cast(src);
-	REQUIRE(scalar_near_equal(vector_get_x(dst), -2.65, 1.0e-6));
-	REQUIRE(scalar_near_equal(vector_get_y(dst), 2.996113, 1.0e-6));
-	REQUIRE(scalar_near_equal(vector_get_z(dst), 0.68123521, 1.0e-6));
-	REQUIRE(scalar_near_equal(vector_get_w(dst), -5.9182, 1.0e-6));
+	test_vector_mix_impl<vector4f, float, mix4::w>(1.0e-6f);
 }

--- a/tests/sources/test_vector4f_mix_x.cpp
+++ b/tests/sources/test_vector4f_mix_x.cpp
@@ -25,20 +25,7 @@
 
 #include "test_vector4_impl.h"
 
-TEST_CASE("vector4f math", "[math][vector4]")
+TEST_CASE("vector4f vector_mix<x * * *>", "[math][vector4]")
 {
-#if defined(RTM_NO_INTRINSICS)
-	const float threshold = 1.0e-4f;
-#else
-	const float threshold = 1.0e-5f;
-#endif
-
-	test_vector4_impl<float>(threshold);
-
-	const vector4f src = vector_set(-2.65f, 2.996113f, 0.68123521f, -5.9182f);
-	const vector4d dst = vector_cast(src);
-	REQUIRE(scalar_near_equal(vector_get_x(dst), -2.65, 1.0e-6));
-	REQUIRE(scalar_near_equal(vector_get_y(dst), 2.996113, 1.0e-6));
-	REQUIRE(scalar_near_equal(vector_get_z(dst), 0.68123521, 1.0e-6));
-	REQUIRE(scalar_near_equal(vector_get_w(dst), -5.9182, 1.0e-6));
+	test_vector_mix_impl<vector4f, float, mix4::x>(1.0e-6f);
 }

--- a/tests/sources/test_vector4f_mix_y.cpp
+++ b/tests/sources/test_vector4f_mix_y.cpp
@@ -25,20 +25,7 @@
 
 #include "test_vector4_impl.h"
 
-TEST_CASE("vector4f math", "[math][vector4]")
+TEST_CASE("vector4f vector_mix<y * * *>", "[math][vector4]")
 {
-#if defined(RTM_NO_INTRINSICS)
-	const float threshold = 1.0e-4f;
-#else
-	const float threshold = 1.0e-5f;
-#endif
-
-	test_vector4_impl<float>(threshold);
-
-	const vector4f src = vector_set(-2.65f, 2.996113f, 0.68123521f, -5.9182f);
-	const vector4d dst = vector_cast(src);
-	REQUIRE(scalar_near_equal(vector_get_x(dst), -2.65, 1.0e-6));
-	REQUIRE(scalar_near_equal(vector_get_y(dst), 2.996113, 1.0e-6));
-	REQUIRE(scalar_near_equal(vector_get_z(dst), 0.68123521, 1.0e-6));
-	REQUIRE(scalar_near_equal(vector_get_w(dst), -5.9182, 1.0e-6));
+	test_vector_mix_impl<vector4f, float, mix4::y>(1.0e-6f);
 }

--- a/tests/sources/test_vector4f_mix_z.cpp
+++ b/tests/sources/test_vector4f_mix_z.cpp
@@ -25,20 +25,7 @@
 
 #include "test_vector4_impl.h"
 
-TEST_CASE("vector4f math", "[math][vector4]")
+TEST_CASE("vector4f vector_mix<z * * *>", "[math][vector4]")
 {
-#if defined(RTM_NO_INTRINSICS)
-	const float threshold = 1.0e-4f;
-#else
-	const float threshold = 1.0e-5f;
-#endif
-
-	test_vector4_impl<float>(threshold);
-
-	const vector4f src = vector_set(-2.65f, 2.996113f, 0.68123521f, -5.9182f);
-	const vector4d dst = vector_cast(src);
-	REQUIRE(scalar_near_equal(vector_get_x(dst), -2.65, 1.0e-6));
-	REQUIRE(scalar_near_equal(vector_get_y(dst), 2.996113, 1.0e-6));
-	REQUIRE(scalar_near_equal(vector_get_z(dst), 0.68123521, 1.0e-6));
-	REQUIRE(scalar_near_equal(vector_get_w(dst), -5.9182, 1.0e-6));
+	test_vector_mix_impl<vector4f, float, mix4::z>(1.0e-6f);
 }

--- a/tools/release_scripts/test_everything.py
+++ b/tools/release_scripts/test_everything.py
@@ -5,7 +5,7 @@ import sys
 
 def get_platform_compilers():
 	if platform.system() == 'Windows':
-		return [ 'vs2015', 'vs2017' ]
+		return [ 'vs2015', 'vs2017', 'vs2019' ]
 	elif platform.system() == 'Linux':
 		return [ 'gcc5', 'gcc6', 'gcc7', 'gcc8', 'clang4', 'clang5', 'clang6' ]
 	elif platform.system() == 'Darwin':


### PR DESCRIPTION
This keeps it in sync with the proposed ACL VS2019 changes.