### PR TITLE
chore: clang-cl fixes

### DIFF
--- a/includes/rtm/impl/compiler_utils.h
+++ b/includes/rtm/impl/compiler_utils.h
@@ -30,7 +30,7 @@
 // To do this, every header is wrapped in two macros to push and pop the necessary
 // pragmas.
 //////////////////////////////////////////////////////////////////////////
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) && !defined(__clang__)
 	#define RTM_IMPL_FILE_PRAGMA_PUSH \
 		/* Disable fast math, it can hurt precision for little to no performance gain due to the heavy usage of intrinsics. */ \
 		__pragma(float_control(precise, on, push))

--- a/includes/rtm/packing/quatf.h
+++ b/includes/rtm/packing/quatf.h
@@ -63,7 +63,7 @@ namespace rtm
 	inline quatf RTM_SIMD_CALL quat_from_positive_w(vector4f_arg0 input) RTM_NO_EXCEPT
 	{
 #if defined(RTM_SSE2_INTRINSICS)
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) && !defined(__clang__)
 		constexpr __m128i masks = { 0xFFU, 0xFFU, 0xFFU, 0x7FU, 0xFFU, 0xFFU, 0xFFU, 0x7FU, 0xFFU, 0xFFU, 0xFFU, 0x7FU, 0xFFU, 0xFFU, 0xFFU, 0x7FU };
 #else
 		constexpr __m128i masks = { 0x7FFFFFFF7FFFFFFFULL, 0x7FFFFFFF7FFFFFFFULL };

--- a/includes/rtm/scalarf.h
+++ b/includes/rtm/scalarf.h
@@ -117,7 +117,7 @@ namespace rtm
 	inline float scalar_abs(float input) RTM_NO_EXCEPT
 	{
 #if defined(RTM_SSE2_INTRINSICS)
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) && !defined(__clang__)
 		constexpr __m128i masks = { 0xFFU, 0xFFU, 0xFFU, 0x7FU, 0xFFU, 0xFFU, 0xFFU, 0x7FU, 0xFFU, 0xFFU, 0xFFU, 0x7FU, 0xFFU, 0xFFU, 0xFFU, 0x7FU };
 #else
 		constexpr __m128i masks = { 0x7FFFFFFF7FFFFFFFULL, 0x7FFFFFFF7FFFFFFFULL };
@@ -143,7 +143,7 @@ namespace rtm
 	//////////////////////////////////////////////////////////////////////////
 	// Returns the reciprocal square root of the input.
 	//////////////////////////////////////////////////////////////////////////
-#if defined(_MSC_VER) && _MSC_VER >= 1920 && defined(_M_X64) && defined(RTM_SSE2_INTRINSICS) && !defined(RTM_AVX_INTRINSICS)
+#if defined(_MSC_VER) && !defined(__clang__) && _MSC_VER >= 1920 && defined(_M_X64) && defined(RTM_SSE2_INTRINSICS) && !defined(RTM_AVX_INTRINSICS)
 	// HACK!!! Visual Studio 2019 has a code generation bug triggered by the code below, disable optimizations for now
 	// Bug only happens with x64 SSE2, not with AVX nor with x86
 	#pragma optimize("", off)
@@ -172,7 +172,7 @@ namespace rtm
 		return 1.0F / scalar_sqrt(input);
 #endif
 	}
-#if defined(_MSC_VER) && _MSC_VER >= 1920 && defined(_M_X64) && defined(RTM_SSE2_INTRINSICS) && !defined(RTM_AVX_INTRINSICS)
+#if defined(_MSC_VER) && !defined(__clang__) && _MSC_VER >= 1920 && defined(_M_X64) && defined(RTM_SSE2_INTRINSICS) && !defined(RTM_AVX_INTRINSICS)
 	// HACK!!! See comment above
 	#pragma optimize("", on)
 #endif
@@ -508,7 +508,7 @@ namespace rtm
 	//////////////////////////////////////////////////////////////////////////
 	inline scalarf RTM_SIMD_CALL scalar_abs(scalarf_arg0 input) RTM_NO_EXCEPT
 	{
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) && !defined(__clang__)
 		constexpr __m128i masks = { 0xFFU, 0xFFU, 0xFFU, 0x7FU, 0xFFU, 0xFFU, 0xFFU, 0x7FU, 0xFFU, 0xFFU, 0xFFU, 0x7FU, 0xFFU, 0xFFU, 0xFFU, 0x7FU };
 #else
 		constexpr __m128i masks = { 0x7FFFFFFF7FFFFFFFULL, 0x7FFFFFFF7FFFFFFFULL };

--- a/includes/rtm/vector4f.h
+++ b/includes/rtm/vector4f.h
@@ -556,7 +556,7 @@ namespace rtm
 	inline vector4f RTM_SIMD_CALL vector_abs(vector4f_arg0 input) RTM_NO_EXCEPT
 	{
 #if defined(RTM_SSE2_INTRINSICS)
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) && !defined(__clang__)
 		constexpr __m128i masks = { 0xFFU, 0xFFU, 0xFFU, 0x7FU, 0xFFU, 0xFFU, 0xFFU, 0x7FU, 0xFFU, 0xFFU, 0xFFU, 0x7FU, 0xFFU, 0xFFU, 0xFFU, 0x7FU };
 #else
 		constexpr __m128i masks = { 0x7FFFFFFF7FFFFFFFULL, 0x7FFFFFFF7FFFFFFFULL };


### PR DESCRIPTION
Clang defines `_MSC_VER` when compiling with `clang-cl` but fails to compile some MSVC specific syntax. This commit simply adds a `!defined(__clang__)` condition where required.