### PR TITLE
fix: avoid store-forwarding penalty when benchmarking

### DIFF
--- a/includes/rtm/impl/compiler_utils.h
+++ b/includes/rtm/impl/compiler_utils.h
@@ -41,3 +41,25 @@
 	#define RTM_IMPL_FILE_PRAGMA_PUSH
 	#define RTM_IMPL_FILE_PRAGMA_POP
 #endif
+
+//////////////////////////////////////////////////////////////////////////
+// Force inline macros for when it is necessary.
+//////////////////////////////////////////////////////////////////////////
+#if defined(_MSC_VER) && !defined(__clang__)
+	#define RTM_FORCE_INLINE __forceinline
+#elif defined(__GNUG__) || defined(__clang__)
+	#define RTM_FORCE_INLINE __attribute__((always_inline)) inline
+#else
+	#define RTM_FORCE_INLINE inline
+#endif
+
+//////////////////////////////////////////////////////////////////////////
+// Force no-inline macros for when it is necessary.
+//////////////////////////////////////////////////////////////////////////
+#if defined(_MSC_VER) && !defined(__clang__)
+	#define RTM_FORCE_NOINLINE __declspec(noinline)
+#elif defined(__GNUG__) || defined(__clang__)
+	#define RTM_FORCE_NOINLINE __attribute__((noinline))
+#else
+	#define RTM_FORCE_NOINLINE
+#endif

--- a/tools/bench/sources/bench_quat_conjugate.cpp
+++ b/tools/bench/sources/bench_quat_conjugate.cpp
@@ -36,6 +36,8 @@ RTM_FORCE_NOINLINE quatf RTM_SIMD_CALL quat_conjugate_scalar(quatf_arg0 input) R
 	return quat_set(-quat_get_x(input), -quat_get_y(input), -quat_get_z(input), quat_get_w(input));
 }
 
+// Wins on Haswell laptop x64 AVX
+// It seems that on haswell, xor incurs a domain switch penalty and is slower.
 RTM_FORCE_NOINLINE quatf RTM_SIMD_CALL quat_conjugate_mul(quatf_arg0 input) RTM_NO_EXCEPT
 {
 #if defined(RTM_SSE2_INTRINSICS)
@@ -54,7 +56,6 @@ RTM_FORCE_NOINLINE quatf RTM_SIMD_CALL quat_conjugate_mul(quatf_arg0 input) RTM_
 // Wins on iPad Pro ARM64
 // Wins on Pixel 3 ARM64
 // mul/XOR/neg all end up taking 3 instructions, all dependent but XOR is fastest.
-// Wins on Haswell laptop x64 AVX
 // Wins on Ryzen 2990X desktop clang9 x64 AVX
 // Performance is about the same as mul.
 RTM_FORCE_NOINLINE quatf RTM_SIMD_CALL quat_conjugate_xor(quatf_arg0 input) RTM_NO_EXCEPT

--- a/tools/bench/sources/bench_quat_conjugate.cpp
+++ b/tools/bench/sources/bench_quat_conjugate.cpp
@@ -28,6 +28,9 @@
 
 using namespace rtm;
 
+// Wins on Ryzen 2990X desktop VS2017 x64 AVX
+// Very odd but consistent result. mul/xor have about the same performance in this profile
+// but xor should be faster.
 RTM_FORCE_NOINLINE quatf RTM_SIMD_CALL quat_conjugate_scalar(quatf_arg0 input) RTM_NO_EXCEPT
 {
 	return quat_set(-quat_get_x(input), -quat_get_y(input), -quat_get_z(input), quat_get_w(input));
@@ -48,6 +51,10 @@ RTM_FORCE_NOINLINE quatf RTM_SIMD_CALL quat_conjugate_mul(quatf_arg0 input) RTM_
 }
 
 #if defined(RTM_SSE2_INTRINSICS) || defined(RTM_NEON_INTRINSICS)
+// Wins on iPad Pro ARM64
+// Wins on Pixel 3 ARM64
+// mul/XOR/neg all end up taking 3 instructions, all dependent but XOR is fastest.
+// Wins on Haswell laptop x64 AVX
 RTM_FORCE_NOINLINE quatf RTM_SIMD_CALL quat_conjugate_xor(quatf_arg0 input) RTM_NO_EXCEPT
 {
 #if defined(RTM_SSE2_INTRINSICS)
@@ -64,6 +71,8 @@ RTM_FORCE_NOINLINE quatf RTM_SIMD_CALL quat_conjugate_xor(quatf_arg0 input) RTM_
 #endif
 
 #if defined(RTM_NEON_INTRINSICS)
+// Wins on Pixel 3 ARMv7
+// mul/XOR/neg all end up taking 3 instructions, all dependent but neg is fastest.
 RTM_FORCE_NOINLINE quatf RTM_SIMD_CALL quat_conjugate_neg(quatf_arg0 input) RTM_NO_EXCEPT
 {
 	const float32x4_t neg_input = vnegq_f32(input);

--- a/tools/bench/sources/bench_quat_conjugate.cpp
+++ b/tools/bench/sources/bench_quat_conjugate.cpp
@@ -28,12 +28,12 @@
 
 using namespace rtm;
 
-inline quatf RTM_SIMD_CALL quat_conjugate_scalar(quatf_arg0 input) RTM_NO_EXCEPT
+RTM_FORCE_NOINLINE quatf RTM_SIMD_CALL quat_conjugate_scalar(quatf_arg0 input) RTM_NO_EXCEPT
 {
 	return quat_set(-quat_get_x(input), -quat_get_y(input), -quat_get_z(input), quat_get_w(input));
 }
 
-inline quatf RTM_SIMD_CALL quat_conjugate_mul(quatf_arg0 input) RTM_NO_EXCEPT
+RTM_FORCE_NOINLINE quatf RTM_SIMD_CALL quat_conjugate_mul(quatf_arg0 input) RTM_NO_EXCEPT
 {
 #if defined(RTM_SSE2_INTRINSICS)
 	constexpr __m128 signs = { -1.0f, -1.0f, -1.0f, 1.0f };
@@ -48,7 +48,7 @@ inline quatf RTM_SIMD_CALL quat_conjugate_mul(quatf_arg0 input) RTM_NO_EXCEPT
 }
 
 #if defined(RTM_SSE2_INTRINSICS) || defined(RTM_NEON_INTRINSICS)
-inline quatf RTM_SIMD_CALL quat_conjugate_xor(quatf_arg0 input) RTM_NO_EXCEPT
+RTM_FORCE_NOINLINE quatf RTM_SIMD_CALL quat_conjugate_xor(quatf_arg0 input) RTM_NO_EXCEPT
 {
 #if defined(RTM_SSE2_INTRINSICS)
 	constexpr __m128 signs = { -0.0f, -0.0f, -0.0f, 0.0f };
@@ -64,7 +64,7 @@ inline quatf RTM_SIMD_CALL quat_conjugate_xor(quatf_arg0 input) RTM_NO_EXCEPT
 #endif
 
 #if defined(RTM_NEON_INTRINSICS)
-inline quatf RTM_SIMD_CALL quat_conjugate_neg(quatf_arg0 input) RTM_NO_EXCEPT
+RTM_FORCE_NOINLINE quatf RTM_SIMD_CALL quat_conjugate_neg(quatf_arg0 input) RTM_NO_EXCEPT
 {
 	const float32x4_t neg_input = vnegq_f32(input);
 	return vsetq_lane_f32(vgetq_lane_f32(input, 3), neg_input, 3);

--- a/tools/bench/sources/bench_quat_conjugate.cpp
+++ b/tools/bench/sources/bench_quat_conjugate.cpp
@@ -55,6 +55,8 @@ RTM_FORCE_NOINLINE quatf RTM_SIMD_CALL quat_conjugate_mul(quatf_arg0 input) RTM_
 // Wins on Pixel 3 ARM64
 // mul/XOR/neg all end up taking 3 instructions, all dependent but XOR is fastest.
 // Wins on Haswell laptop x64 AVX
+// Wins on Ryzen 2990X desktop clang9 x64 AVX
+// Performance is about the same as mul.
 RTM_FORCE_NOINLINE quatf RTM_SIMD_CALL quat_conjugate_xor(quatf_arg0 input) RTM_NO_EXCEPT
 {
 #if defined(RTM_SSE2_INTRINSICS)

--- a/tools/bench/sources/bench_quat_conjugate.cpp
+++ b/tools/bench/sources/bench_quat_conjugate.cpp
@@ -74,9 +74,22 @@ inline quatf RTM_SIMD_CALL quat_conjugate_neg(quatf_arg0 input) RTM_NO_EXCEPT
 static void bm_quat_conjugate_scalar(benchmark::State& state)
 {
 	quatf q0 = quat_identity();
+	quatf q1 = quat_identity();
+	quatf q2 = quat_identity();
+	quatf q3 = quat_identity();
 
 	for (auto _ : state)
-		benchmark::DoNotOptimize(q0 = quat_conjugate_scalar(q0));
+	{
+		q0 = quat_conjugate_scalar(q0);
+		q1 = quat_conjugate_scalar(q1);
+		q2 = quat_conjugate_scalar(q2);
+		q3 = quat_conjugate_scalar(q3);
+	}
+
+	benchmark::DoNotOptimize(q0);
+	benchmark::DoNotOptimize(q1);
+	benchmark::DoNotOptimize(q2);
+	benchmark::DoNotOptimize(q3);
 }
 
 BENCHMARK(bm_quat_conjugate_scalar);
@@ -84,9 +97,22 @@ BENCHMARK(bm_quat_conjugate_scalar);
 static void bm_quat_conjugate_mul(benchmark::State& state)
 {
 	quatf q0 = quat_identity();
+	quatf q1 = quat_identity();
+	quatf q2 = quat_identity();
+	quatf q3 = quat_identity();
 
 	for (auto _ : state)
-		benchmark::DoNotOptimize(q0 = quat_conjugate_mul(q0));
+	{
+		q0 = quat_conjugate_mul(q0);
+		q1 = quat_conjugate_mul(q1);
+		q2 = quat_conjugate_mul(q2);
+		q3 = quat_conjugate_mul(q3);
+	}
+
+	benchmark::DoNotOptimize(q0);
+	benchmark::DoNotOptimize(q1);
+	benchmark::DoNotOptimize(q2);
+	benchmark::DoNotOptimize(q3);
 }
 
 BENCHMARK(bm_quat_conjugate_mul);
@@ -95,9 +121,22 @@ BENCHMARK(bm_quat_conjugate_mul);
 static void bm_quat_conjugate_xor(benchmark::State& state)
 {
 	quatf q0 = quat_identity();
+	quatf q1 = quat_identity();
+	quatf q2 = quat_identity();
+	quatf q3 = quat_identity();
 
 	for (auto _ : state)
-		benchmark::DoNotOptimize(q0 = quat_conjugate_xor(q0));
+	{
+		q0 = quat_conjugate_xor(q0);
+		q1 = quat_conjugate_xor(q1);
+		q2 = quat_conjugate_xor(q2);
+		q3 = quat_conjugate_xor(q3);
+	}
+
+	benchmark::DoNotOptimize(q0);
+	benchmark::DoNotOptimize(q1);
+	benchmark::DoNotOptimize(q2);
+	benchmark::DoNotOptimize(q3);
 }
 
 BENCHMARK(bm_quat_conjugate_xor);
@@ -107,9 +146,22 @@ BENCHMARK(bm_quat_conjugate_xor);
 static void bm_quat_conjugate_neg(benchmark::State& state)
 {
 	quatf q0 = quat_identity();
+	quatf q1 = quat_identity();
+	quatf q2 = quat_identity();
+	quatf q3 = quat_identity();
 
 	for (auto _ : state)
-		benchmark::DoNotOptimize(q0 = quat_conjugate_neg(q0));
+	{
+		q0 = quat_conjugate_neg(q0);
+		q1 = quat_conjugate_neg(q1);
+		q2 = quat_conjugate_neg(q2);
+		q3 = quat_conjugate_neg(q3);
+	}
+
+	benchmark::DoNotOptimize(q0);
+	benchmark::DoNotOptimize(q1);
+	benchmark::DoNotOptimize(q2);
+	benchmark::DoNotOptimize(q3);
 }
 
 BENCHMARK(bm_quat_conjugate_neg);

--- a/tools/bench/sources/bench_quat_from_positive_w.cpp
+++ b/tools/bench/sources/bench_quat_from_positive_w.cpp
@@ -49,7 +49,6 @@ RTM_FORCE_NOINLINE quatf RTM_SIMD_CALL quat_from_positive_w_sse4_andnot(vector4f
 	return _mm_insert_ps(input, w, 0x30);
 }
 
-// Wins on Haswell laptop x64 AVX (asm generated is identical to sse4_andnot due to inlining)
 // Wins on Ryzen 2990X desktop clang9 x64 AVX
 RTM_FORCE_NOINLINE quatf RTM_SIMD_CALL quat_from_positive_w_sse4_and(vector4f_arg0 input) RTM_NO_EXCEPT
 {
@@ -69,6 +68,8 @@ RTM_FORCE_NOINLINE quatf RTM_SIMD_CALL quat_from_positive_w_sse4_and(vector4f_ar
 #endif
 
 #if defined(RTM_SSE2_INTRINSICS)
+// Wins on Haswell laptop x64 AVX
+// The various variants are almost all the same.
 // Wins on Ryzen 2990X desktop VS2017 x64 AVX
 // By all accounts, quat_from_positive_w_sse4_and should be faster since it uses nearly the same code
 // except that it needs 1 instruction instead of 2 to set the W component. It ends up being dramatically
@@ -112,6 +113,7 @@ RTM_FORCE_NOINLINE quatf RTM_SIMD_CALL quat_from_positive_w_sse2_and2(vector4f_a
 
 #if defined(RTM_NEON_INTRINSICS)
 // Wins on iPad Pro ARM64
+// Same perf as ref
 // Wins on Pixel 3 ARM64
 // Wins on Pixel 3 ARMv7
 RTM_FORCE_NOINLINE quatf RTM_SIMD_CALL quat_from_positive_w_neon(vector4f_arg0 input) RTM_NO_EXCEPT

--- a/tools/bench/sources/bench_quat_from_positive_w.cpp
+++ b/tools/bench/sources/bench_quat_from_positive_w.cpp
@@ -49,6 +49,7 @@ RTM_FORCE_NOINLINE quatf RTM_SIMD_CALL quat_from_positive_w_sse4_andnot(vector4f
 	return _mm_insert_ps(input, w, 0x30);
 }
 
+// Wins on Haswell laptop x64 AVX (asm generated is identical to sse4_andnot due to inlining)
 RTM_FORCE_NOINLINE quatf RTM_SIMD_CALL quat_from_positive_w_sse4_and(vector4f_arg0 input) RTM_NO_EXCEPT
 {
 #if defined(_MSC_VER)
@@ -67,6 +68,11 @@ RTM_FORCE_NOINLINE quatf RTM_SIMD_CALL quat_from_positive_w_sse4_and(vector4f_ar
 #endif
 
 #if defined(RTM_SSE2_INTRINSICS)
+// Wins on Ryzen 2990X desktop VS2017 x64 AVX
+// By all accounts, quat_from_positive_w_sse4_and should be faster since it uses nearly the same code
+// except that it needs 1 instruction instead of 2 to set the W component. It ends up being dramatically
+// slower because VS2017 decides to use XMM6 and spills it on the stack instead of using the volatile XMM5
+// register which is unused and doesn't need spilling...
 RTM_FORCE_NOINLINE quatf RTM_SIMD_CALL quat_from_positive_w_sse2_and(vector4f_arg0 input) RTM_NO_EXCEPT
 {
 #if defined(_MSC_VER)
@@ -104,6 +110,9 @@ RTM_FORCE_NOINLINE quatf RTM_SIMD_CALL quat_from_positive_w_sse2_and2(vector4f_a
 #endif
 
 #if defined(RTM_NEON_INTRINSICS)
+// Wins on iPad Pro ARM64
+// Wins on Pixel 3 ARM64
+// Wins on Pixel 3 ARMv7
 RTM_FORCE_NOINLINE quatf RTM_SIMD_CALL quat_from_positive_w_neon(vector4f_arg0 input) RTM_NO_EXCEPT
 {
 	float32x4_t x2y2z2 = vmulq_f32(input, input);

--- a/tools/bench/sources/bench_quat_from_positive_w.cpp
+++ b/tools/bench/sources/bench_quat_from_positive_w.cpp
@@ -116,9 +116,22 @@ inline quatf RTM_SIMD_CALL quat_from_positive_w_neon(vector4f_arg0 input) RTM_NO
 static void bm_quat_from_positive_w_scalar(benchmark::State& state)
 {
 	quatf q0 = quat_identity();
+	quatf q1 = quat_identity();
+	quatf q2 = quat_identity();
+	quatf q3 = quat_identity();
 
 	for (auto _ : state)
-		benchmark::DoNotOptimize(q0 = quat_from_positive_w_scalar(q0));
+	{
+		q0 = quat_from_positive_w_scalar(q0);
+		q1 = quat_from_positive_w_scalar(q1);
+		q2 = quat_from_positive_w_scalar(q2);
+		q3 = quat_from_positive_w_scalar(q3);
+	}
+
+	benchmark::DoNotOptimize(q0);
+	benchmark::DoNotOptimize(q1);
+	benchmark::DoNotOptimize(q2);
+	benchmark::DoNotOptimize(q3);
 }
 
 BENCHMARK(bm_quat_from_positive_w_scalar);
@@ -127,9 +140,22 @@ BENCHMARK(bm_quat_from_positive_w_scalar);
 static void bm_quat_from_positive_w_sse4_andnot(benchmark::State& state)
 {
 	quatf q0 = quat_identity();
+	quatf q1 = quat_identity();
+	quatf q2 = quat_identity();
+	quatf q3 = quat_identity();
 
 	for (auto _ : state)
-		benchmark::DoNotOptimize(q0 = quat_from_positive_w_sse4_andnot(q0));
+	{
+		q0 = quat_from_positive_w_sse4_andnot(q0);
+		q1 = quat_from_positive_w_sse4_andnot(q1);
+		q2 = quat_from_positive_w_sse4_andnot(q2);
+		q3 = quat_from_positive_w_sse4_andnot(q3);
+	}
+
+	benchmark::DoNotOptimize(q0);
+	benchmark::DoNotOptimize(q1);
+	benchmark::DoNotOptimize(q2);
+	benchmark::DoNotOptimize(q3);
 }
 
 BENCHMARK(bm_quat_from_positive_w_sse4_andnot);
@@ -137,9 +163,22 @@ BENCHMARK(bm_quat_from_positive_w_sse4_andnot);
 static void bm_quat_from_positive_w_sse4_and(benchmark::State& state)
 {
 	quatf q0 = quat_identity();
+	quatf q1 = quat_identity();
+	quatf q2 = quat_identity();
+	quatf q3 = quat_identity();
 
 	for (auto _ : state)
-		benchmark::DoNotOptimize(q0 = quat_from_positive_w_sse4_and(q0));
+	{
+		q0 = quat_from_positive_w_sse4_and(q0);
+		q1 = quat_from_positive_w_sse4_and(q1);
+		q2 = quat_from_positive_w_sse4_and(q2);
+		q3 = quat_from_positive_w_sse4_and(q3);
+	}
+
+	benchmark::DoNotOptimize(q0);
+	benchmark::DoNotOptimize(q1);
+	benchmark::DoNotOptimize(q2);
+	benchmark::DoNotOptimize(q3);
 }
 
 BENCHMARK(bm_quat_from_positive_w_sse4_and);
@@ -149,9 +188,22 @@ BENCHMARK(bm_quat_from_positive_w_sse4_and);
 static void bm_quat_from_positive_w_sse2_and(benchmark::State& state)
 {
 	quatf q0 = quat_identity();
+	quatf q1 = quat_identity();
+	quatf q2 = quat_identity();
+	quatf q3 = quat_identity();
 
 	for (auto _ : state)
-		benchmark::DoNotOptimize(q0 = quat_from_positive_w_sse2_and(q0));
+	{
+		q0 = quat_from_positive_w_sse2_and(q0);
+		q1 = quat_from_positive_w_sse2_and(q1);
+		q2 = quat_from_positive_w_sse2_and(q2);
+		q3 = quat_from_positive_w_sse2_and(q3);
+	}
+
+	benchmark::DoNotOptimize(q0);
+	benchmark::DoNotOptimize(q1);
+	benchmark::DoNotOptimize(q2);
+	benchmark::DoNotOptimize(q3);
 }
 
 BENCHMARK(bm_quat_from_positive_w_sse2_and);
@@ -159,9 +211,22 @@ BENCHMARK(bm_quat_from_positive_w_sse2_and);
 static void bm_quat_from_positive_w_sse2_and2(benchmark::State& state)
 {
 	quatf q0 = quat_identity();
+	quatf q1 = quat_identity();
+	quatf q2 = quat_identity();
+	quatf q3 = quat_identity();
 
 	for (auto _ : state)
-		benchmark::DoNotOptimize(q0 = quat_from_positive_w_sse2_and2(q0));
+	{
+		q0 = quat_from_positive_w_sse2_and2(q0);
+		q1 = quat_from_positive_w_sse2_and2(q1);
+		q2 = quat_from_positive_w_sse2_and2(q2);
+		q3 = quat_from_positive_w_sse2_and2(q3);
+	}
+
+	benchmark::DoNotOptimize(q0);
+	benchmark::DoNotOptimize(q1);
+	benchmark::DoNotOptimize(q2);
+	benchmark::DoNotOptimize(q3);
 }
 
 BENCHMARK(bm_quat_from_positive_w_sse2_and2);
@@ -171,9 +236,22 @@ BENCHMARK(bm_quat_from_positive_w_sse2_and2);
 static void bm_quat_from_positive_w_neon(benchmark::State& state)
 {
 	quatf q0 = quat_identity();
+	quatf q1 = quat_identity();
+	quatf q2 = quat_identity();
+	quatf q3 = quat_identity();
 
 	for (auto _ : state)
-		benchmark::DoNotOptimize(q0 = quat_from_positive_w_neon(q0));
+	{
+		q0 = quat_from_positive_w_neon(q0);
+		q1 = quat_from_positive_w_neon(q1);
+		q2 = quat_from_positive_w_neon(q2);
+		q3 = quat_from_positive_w_neon(q3);
+	}
+
+	benchmark::DoNotOptimize(q0);
+	benchmark::DoNotOptimize(q1);
+	benchmark::DoNotOptimize(q2);
+	benchmark::DoNotOptimize(q3);
 }
 
 BENCHMARK(bm_quat_from_positive_w_neon);

--- a/tools/bench/sources/bench_quat_from_positive_w.cpp
+++ b/tools/bench/sources/bench_quat_from_positive_w.cpp
@@ -50,6 +50,7 @@ RTM_FORCE_NOINLINE quatf RTM_SIMD_CALL quat_from_positive_w_sse4_andnot(vector4f
 }
 
 // Wins on Haswell laptop x64 AVX (asm generated is identical to sse4_andnot due to inlining)
+// Wins on Ryzen 2990X desktop clang9 x64 AVX
 RTM_FORCE_NOINLINE quatf RTM_SIMD_CALL quat_from_positive_w_sse4_and(vector4f_arg0 input) RTM_NO_EXCEPT
 {
 #if defined(_MSC_VER)

--- a/tools/bench/sources/bench_quat_from_positive_w.cpp
+++ b/tools/bench/sources/bench_quat_from_positive_w.cpp
@@ -28,7 +28,7 @@
 
 using namespace rtm;
 
-inline quatf RTM_SIMD_CALL quat_from_positive_w_scalar(vector4f_arg0 input) RTM_NO_EXCEPT
+RTM_FORCE_NOINLINE quatf RTM_SIMD_CALL quat_from_positive_w_scalar(vector4f_arg0 input) RTM_NO_EXCEPT
 {
 	// Operation order is important here, due to rounding, ((1.0 - (X*X)) - Y*Y) - Z*Z is more accurate than 1.0 - dot3(xyz, xyz)
 	float w_squared = ((1.0F - vector_get_x(input) * vector_get_x(input)) - vector_get_y(input) * vector_get_y(input)) - vector_get_z(input) * vector_get_z(input);
@@ -39,7 +39,7 @@ inline quatf RTM_SIMD_CALL quat_from_positive_w_scalar(vector4f_arg0 input) RTM_
 }
 
 #if defined(RTM_SSE4_INTRINSICS)
-inline quatf RTM_SIMD_CALL quat_from_positive_w_sse4_andnot(vector4f_arg0 input) RTM_NO_EXCEPT
+RTM_FORCE_NOINLINE quatf RTM_SIMD_CALL quat_from_positive_w_sse4_andnot(vector4f_arg0 input) RTM_NO_EXCEPT
 {
 	__m128 x2y2z2 = _mm_mul_ps(input, input);
 	__m128 one = _mm_set_ss(1.0F);
@@ -49,7 +49,7 @@ inline quatf RTM_SIMD_CALL quat_from_positive_w_sse4_andnot(vector4f_arg0 input)
 	return _mm_insert_ps(input, w, 0x30);
 }
 
-inline quatf RTM_SIMD_CALL quat_from_positive_w_sse4_and(vector4f_arg0 input) RTM_NO_EXCEPT
+RTM_FORCE_NOINLINE quatf RTM_SIMD_CALL quat_from_positive_w_sse4_and(vector4f_arg0 input) RTM_NO_EXCEPT
 {
 #if defined(_MSC_VER)
 	constexpr __m128i masks = { 0xFFU, 0xFFU, 0xFFU, 0x7FU, 0xFFU, 0xFFU, 0xFFU, 0x7FU, 0xFFU, 0xFFU, 0xFFU, 0x7FU, 0xFFU, 0xFFU, 0xFFU, 0x7FU };
@@ -67,7 +67,7 @@ inline quatf RTM_SIMD_CALL quat_from_positive_w_sse4_and(vector4f_arg0 input) RT
 #endif
 
 #if defined(RTM_SSE2_INTRINSICS)
-inline quatf RTM_SIMD_CALL quat_from_positive_w_sse2_and(vector4f_arg0 input) RTM_NO_EXCEPT
+RTM_FORCE_NOINLINE quatf RTM_SIMD_CALL quat_from_positive_w_sse2_and(vector4f_arg0 input) RTM_NO_EXCEPT
 {
 #if defined(_MSC_VER)
 	constexpr __m128i masks = { 0xFFU, 0xFFU, 0xFFU, 0x7FU, 0xFFU, 0xFFU, 0xFFU, 0x7FU, 0xFFU, 0xFFU, 0xFFU, 0x7FU, 0xFFU, 0xFFU, 0xFFU, 0x7FU };
@@ -85,7 +85,7 @@ inline quatf RTM_SIMD_CALL quat_from_positive_w_sse2_and(vector4f_arg0 input) RT
 	return _mm_shuffle_ps(result_wyzx, result_wyzx, _MM_SHUFFLE(0, 2, 1, 3));
 }
 
-inline quatf RTM_SIMD_CALL quat_from_positive_w_sse2_and2(vector4f_arg0 input) RTM_NO_EXCEPT
+RTM_FORCE_NOINLINE quatf RTM_SIMD_CALL quat_from_positive_w_sse2_and2(vector4f_arg0 input) RTM_NO_EXCEPT
 {
 #if defined(_MSC_VER)
 	constexpr __m128i masks = { 0xFFU, 0xFFU, 0xFFU, 0x7FU, 0xFFU, 0xFFU, 0xFFU, 0x7FU, 0xFFU, 0xFFU, 0xFFU, 0x7FU, 0xFFU, 0xFFU, 0xFFU, 0x7FU };
@@ -104,7 +104,7 @@ inline quatf RTM_SIMD_CALL quat_from_positive_w_sse2_and2(vector4f_arg0 input) R
 #endif
 
 #if defined(RTM_NEON_INTRINSICS)
-inline quatf RTM_SIMD_CALL quat_from_positive_w_neon(vector4f_arg0 input) RTM_NO_EXCEPT
+RTM_FORCE_NOINLINE quatf RTM_SIMD_CALL quat_from_positive_w_neon(vector4f_arg0 input) RTM_NO_EXCEPT
 {
 	float32x4_t x2y2z2 = vmulq_f32(input, input);
 	float w_squared = ((1.0F - vgetq_lane_f32(x2y2z2, 0)) - vgetq_lane_f32(x2y2z2, 1)) - vgetq_lane_f32(x2y2z2, 2);

--- a/tools/bench/sources/bench_quat_mul.cpp
+++ b/tools/bench/sources/bench_quat_mul.cpp
@@ -28,7 +28,7 @@
 
 using namespace rtm;
 
-inline quatf RTM_SIMD_CALL quat_mul_scalar(quatf_arg0 lhs, quatf_arg1 rhs) RTM_NO_EXCEPT
+RTM_FORCE_NOINLINE quatf RTM_SIMD_CALL quat_mul_scalar(quatf_arg0 lhs, quatf_arg1 rhs) RTM_NO_EXCEPT
 {
 	const float lhs_x = quat_get_x(lhs);
 	const float lhs_y = quat_get_y(lhs);
@@ -49,7 +49,7 @@ inline quatf RTM_SIMD_CALL quat_mul_scalar(quatf_arg0 lhs, quatf_arg1 rhs) RTM_N
 }
 
 #if defined(RTM_FMA_INTRINSICS)
-inline quatf RTM_SIMD_CALL quat_mul_fma_mul(quatf_arg0 lhs, quatf_arg1 rhs) RTM_NO_EXCEPT
+RTM_FORCE_NOINLINE quatf RTM_SIMD_CALL quat_mul_fma_mul(quatf_arg0 lhs, quatf_arg1 rhs) RTM_NO_EXCEPT
 {
 	constexpr __m128 control_wzyx = { 1.0f,-1.0f, 1.0f,-1.0f };
 	constexpr __m128 control_zwxy = { 1.0f, 1.0f,-1.0f,-1.0f };
@@ -75,7 +75,7 @@ inline quatf RTM_SIMD_CALL quat_mul_fma_mul(quatf_arg0 lhs, quatf_arg1 rhs) RTM_
 	return _mm_fmadd_ps(lyrz_lxrz_lwrz_lzrz, control_yxwz, result1);
 }
 
-inline quatf RTM_SIMD_CALL quat_mul_fma_xor(quatf_arg0 lhs, quatf_arg1 rhs) RTM_NO_EXCEPT
+RTM_FORCE_NOINLINE quatf RTM_SIMD_CALL quat_mul_fma_xor(quatf_arg0 lhs, quatf_arg1 rhs) RTM_NO_EXCEPT
 {
 	constexpr __m128 control_wzyx = { 0.0f,-0.0f, 0.0f,-0.0f };
 	constexpr __m128 control_zwxy = { 0.0f, 0.0f,-0.0f,-0.0f };
@@ -108,7 +108,7 @@ inline quatf RTM_SIMD_CALL quat_mul_fma_xor(quatf_arg0 lhs, quatf_arg1 rhs) RTM_
 #endif
 
 #if defined(RTM_SSE2_INTRINSICS)
-inline quatf RTM_SIMD_CALL quat_mul_sse_mul(quatf_arg0 lhs, quatf_arg1 rhs) RTM_NO_EXCEPT
+RTM_FORCE_NOINLINE quatf RTM_SIMD_CALL quat_mul_sse_mul(quatf_arg0 lhs, quatf_arg1 rhs) RTM_NO_EXCEPT
 {
 	constexpr __m128 control_wzyx = { 1.0f,-1.0f, 1.0f,-1.0f };
 	constexpr __m128 control_zwxy = { 1.0f, 1.0f,-1.0f,-1.0f };
@@ -140,7 +140,7 @@ inline quatf RTM_SIMD_CALL quat_mul_sse_mul(quatf_arg0 lhs, quatf_arg1 rhs) RTM_
 	return _mm_add_ps(result0, result1);
 }
 
-inline quatf RTM_SIMD_CALL quat_mul_sse_xor(quatf_arg0 lhs, quatf_arg1 rhs) RTM_NO_EXCEPT
+RTM_FORCE_NOINLINE quatf RTM_SIMD_CALL quat_mul_sse_xor(quatf_arg0 lhs, quatf_arg1 rhs) RTM_NO_EXCEPT
 {
 	constexpr __m128 control_wzyx = { 0.0f,-0.0f, 0.0f,-0.0f };
 	constexpr __m128 control_zwxy = { 0.0f, 0.0f,-0.0f,-0.0f };
@@ -174,7 +174,7 @@ inline quatf RTM_SIMD_CALL quat_mul_sse_xor(quatf_arg0 lhs, quatf_arg1 rhs) RTM_
 #endif
 
 #if defined(RTM_NEON_INTRINSICS)
-inline quatf RTM_SIMD_CALL quat_mul_neon_mul(quatf_arg0 lhs, quatf_arg1 rhs) RTM_NO_EXCEPT
+RTM_FORCE_NOINLINE quatf RTM_SIMD_CALL quat_mul_neon_mul(quatf_arg0 lhs, quatf_arg1 rhs) RTM_NO_EXCEPT
 {
 	alignas(16) constexpr float control_wzyx_f[4] = { 1.0f, -1.0f, 1.0f, -1.0f };
 	alignas(16) constexpr float control_zwxy_f[4] = { 1.0f, 1.0f, -1.0f, -1.0f };
@@ -208,7 +208,7 @@ inline quatf RTM_SIMD_CALL quat_mul_neon_mul(quatf_arg0 lhs, quatf_arg1 rhs) RTM
 #endif
 }
 
-inline quatf RTM_SIMD_CALL quat_mul_neon_xor(quatf_arg0 lhs, quatf_arg1 rhs) RTM_NO_EXCEPT
+RTM_FORCE_NOINLINE quatf RTM_SIMD_CALL quat_mul_neon_xor(quatf_arg0 lhs, quatf_arg1 rhs) RTM_NO_EXCEPT
 {
 	alignas(16) constexpr uint32x4_t control_wzyx_f[4] = { 0, 0x80000000U, 0, 0x80000000U };
 	alignas(16) constexpr uint32x4_t control_zwxy_f[4] = { 0, 0, 0x80000000U, 0x80000000U };
@@ -239,7 +239,7 @@ inline quatf RTM_SIMD_CALL quat_mul_neon_xor(quatf_arg0 lhs, quatf_arg1 rhs) RTM
 	return vaddq_f32(vreinterpretq_f32_u32(veorq_u32(vreinterpretq_u32_f32(lyrz_lxrz_lwrz_lzrz), control_yxwz)), result1);
 }
 
-inline quatf RTM_SIMD_CALL quat_mul_neon_neg(quatf_arg0 lhs, quatf_arg1 rhs) RTM_NO_EXCEPT
+RTM_FORCE_NOINLINE quatf RTM_SIMD_CALL quat_mul_neon_neg(quatf_arg0 lhs, quatf_arg1 rhs) RTM_NO_EXCEPT
 {
 	const float32x4_t neg_lhs = vnegq_f32(lhs);														// -t.x, -t.y, -t.z, -t.w
 	const float32x4_t t_zwxy = vrev64q_f32(lhs);														// t.z, t.w, t.x, t.y

--- a/tools/bench/sources/bench_quat_mul.cpp
+++ b/tools/bench/sources/bench_quat_mul.cpp
@@ -142,6 +142,7 @@ RTM_FORCE_NOINLINE quatf RTM_SIMD_CALL quat_mul_sse_mul(quatf_arg0 lhs, quatf_ar
 }
 
 // Wins on Ryzen 2990X desktop VS2017 x64 AVX
+// Wins on Ryzen 2990X desktop clang9 x64 AVX
 RTM_FORCE_NOINLINE quatf RTM_SIMD_CALL quat_mul_sse_xor(quatf_arg0 lhs, quatf_arg1 rhs) RTM_NO_EXCEPT
 {
 	constexpr __m128 control_wzyx = { 0.0f,-0.0f, 0.0f,-0.0f };

--- a/tools/bench/sources/bench_quat_mul.cpp
+++ b/tools/bench/sources/bench_quat_mul.cpp
@@ -274,9 +274,22 @@ inline quatf RTM_SIMD_CALL quat_mul_neon_neg(quatf_arg0 lhs, quatf_arg1 rhs) RTM
 static void bm_quat_mul_scalar(benchmark::State& state)
 {
 	quatf q0 = quat_identity();
+	quatf q1 = quat_identity();
+	quatf q2 = quat_identity();
+	quatf q3 = quat_identity();
 
 	for (auto _ : state)
-		benchmark::DoNotOptimize(q0 = quat_mul_scalar(q0, q0));
+	{
+		q0 = quat_mul_scalar(q0, q0);
+		q1 = quat_mul_scalar(q1, q1);
+		q2 = quat_mul_scalar(q2, q2);
+		q3 = quat_mul_scalar(q3, q3);
+	}
+
+	benchmark::DoNotOptimize(q0);
+	benchmark::DoNotOptimize(q1);
+	benchmark::DoNotOptimize(q2);
+	benchmark::DoNotOptimize(q3);
 }
 
 BENCHMARK(bm_quat_mul_scalar);
@@ -285,9 +298,22 @@ BENCHMARK(bm_quat_mul_scalar);
 static void bm_quat_mul_fma_mul(benchmark::State& state)
 {
 	quatf q0 = quat_identity();
+	quatf q1 = quat_identity();
+	quatf q2 = quat_identity();
+	quatf q3 = quat_identity();
 
 	for (auto _ : state)
-		benchmark::DoNotOptimize(q0 = quat_mul_fma_mul(q0, q0));
+	{
+		q0 = quat_mul_fma_mul(q0, q0);
+		q1 = quat_mul_fma_mul(q1, q1);
+		q2 = quat_mul_fma_mul(q2, q2);
+		q3 = quat_mul_fma_mul(q3, q3);
+	}
+
+	benchmark::DoNotOptimize(q0);
+	benchmark::DoNotOptimize(q1);
+	benchmark::DoNotOptimize(q2);
+	benchmark::DoNotOptimize(q3);
 }
 
 BENCHMARK(bm_quat_mul_fma_mul);
@@ -295,9 +321,22 @@ BENCHMARK(bm_quat_mul_fma_mul);
 static void bm_quat_mul_fma_xor(benchmark::State& state)
 {
 	quatf q0 = quat_identity();
+	quatf q1 = quat_identity();
+	quatf q2 = quat_identity();
+	quatf q3 = quat_identity();
 
 	for (auto _ : state)
-		benchmark::DoNotOptimize(q0 = quat_mul_fma_xor(q0, q0));
+	{
+		q0 = quat_mul_fma_xor(q0, q0);
+		q1 = quat_mul_fma_xor(q1, q1);
+		q2 = quat_mul_fma_xor(q2, q2);
+		q3 = quat_mul_fma_xor(q3, q3);
+	}
+
+	benchmark::DoNotOptimize(q0);
+	benchmark::DoNotOptimize(q1);
+	benchmark::DoNotOptimize(q2);
+	benchmark::DoNotOptimize(q3);
 }
 
 BENCHMARK(bm_quat_mul_fma_xor);
@@ -307,9 +346,22 @@ BENCHMARK(bm_quat_mul_fma_xor);
 static void bm_quat_mul_sse_mul(benchmark::State& state)
 {
 	quatf q0 = quat_identity();
+	quatf q1 = quat_identity();
+	quatf q2 = quat_identity();
+	quatf q3 = quat_identity();
 
 	for (auto _ : state)
-		benchmark::DoNotOptimize(q0 = quat_mul_sse_mul(q0, q0));
+	{
+		q0 = quat_mul_sse_mul(q0, q0);
+		q1 = quat_mul_sse_mul(q1, q1);
+		q2 = quat_mul_sse_mul(q2, q2);
+		q3 = quat_mul_sse_mul(q3, q3);
+	}
+
+	benchmark::DoNotOptimize(q0);
+	benchmark::DoNotOptimize(q1);
+	benchmark::DoNotOptimize(q2);
+	benchmark::DoNotOptimize(q3);
 }
 
 BENCHMARK(bm_quat_mul_sse_mul);
@@ -317,9 +369,22 @@ BENCHMARK(bm_quat_mul_sse_mul);
 static void bm_quat_mul_sse_xor(benchmark::State& state)
 {
 	quatf q0 = quat_identity();
+	quatf q1 = quat_identity();
+	quatf q2 = quat_identity();
+	quatf q3 = quat_identity();
 
 	for (auto _ : state)
-		benchmark::DoNotOptimize(q0 = quat_mul_sse_xor(q0, q0));
+	{
+		q0 = quat_mul_sse_xor(q0, q0);
+		q1 = quat_mul_sse_xor(q1, q1);
+		q2 = quat_mul_sse_xor(q2, q2);
+		q3 = quat_mul_sse_xor(q3, q3);
+	}
+
+	benchmark::DoNotOptimize(q0);
+	benchmark::DoNotOptimize(q1);
+	benchmark::DoNotOptimize(q2);
+	benchmark::DoNotOptimize(q3);
 }
 
 BENCHMARK(bm_quat_mul_sse_xor);
@@ -329,9 +394,22 @@ BENCHMARK(bm_quat_mul_sse_xor);
 static void bm_quat_mul_neon_mul(benchmark::State& state)
 {
 	quatf q0 = quat_identity();
+	quatf q1 = quat_identity();
+	quatf q2 = quat_identity();
+	quatf q3 = quat_identity();
 
 	for (auto _ : state)
-		benchmark::DoNotOptimize(q0 = quat_mul_neon_mul(q0, q0));
+	{
+		q0 = quat_mul_neon_mul(q0, q0);
+		q1 = quat_mul_neon_mul(q1, q1);
+		q2 = quat_mul_neon_mul(q2, q2);
+		q3 = quat_mul_neon_mul(q3, q3);
+	}
+
+	benchmark::DoNotOptimize(q0);
+	benchmark::DoNotOptimize(q1);
+	benchmark::DoNotOptimize(q2);
+	benchmark::DoNotOptimize(q3);
 }
 
 BENCHMARK(bm_quat_mul_neon_mul);
@@ -339,9 +417,22 @@ BENCHMARK(bm_quat_mul_neon_mul);
 static void bm_quat_mul_neon_xor(benchmark::State& state)
 {
 	quatf q0 = quat_identity();
+	quatf q1 = quat_identity();
+	quatf q2 = quat_identity();
+	quatf q3 = quat_identity();
 
 	for (auto _ : state)
-		benchmark::DoNotOptimize(q0 = quat_mul_neon_xor(q0, q0));
+	{
+		q0 = quat_mul_neon_xor(q0, q0);
+		q1 = quat_mul_neon_xor(q1, q1);
+		q2 = quat_mul_neon_xor(q2, q2);
+		q3 = quat_mul_neon_xor(q3, q3);
+	}
+
+	benchmark::DoNotOptimize(q0);
+	benchmark::DoNotOptimize(q1);
+	benchmark::DoNotOptimize(q2);
+	benchmark::DoNotOptimize(q3);
 }
 
 BENCHMARK(bm_quat_mul_neon_xor);
@@ -349,9 +440,22 @@ BENCHMARK(bm_quat_mul_neon_xor);
 static void bm_quat_mul_neon_neg(benchmark::State& state)
 {
 	quatf q0 = quat_identity();
+	quatf q1 = quat_identity();
+	quatf q2 = quat_identity();
+	quatf q3 = quat_identity();
 
 	for (auto _ : state)
-		benchmark::DoNotOptimize(q0 = quat_mul_neon_neg(q0, q0));
+	{
+		q0 = quat_mul_neon_neg(q0, q0);
+		q1 = quat_mul_neon_neg(q1, q1);
+		q2 = quat_mul_neon_neg(q2, q2);
+		q3 = quat_mul_neon_neg(q3, q3);
+	}
+
+	benchmark::DoNotOptimize(q0);
+	benchmark::DoNotOptimize(q1);
+	benchmark::DoNotOptimize(q2);
+	benchmark::DoNotOptimize(q3);
 }
 
 BENCHMARK(bm_quat_mul_neon_neg);

--- a/tools/bench/sources/bench_quat_mul.cpp
+++ b/tools/bench/sources/bench_quat_mul.cpp
@@ -109,6 +109,7 @@ RTM_FORCE_NOINLINE quatf RTM_SIMD_CALL quat_mul_fma_xor(quatf_arg0 lhs, quatf_ar
 
 #if defined(RTM_SSE2_INTRINSICS)
 // Wins on Haswell laptop x64 AVX
+// It seems that on haswell, xor incurs a domain switch penalty and is slower.
 RTM_FORCE_NOINLINE quatf RTM_SIMD_CALL quat_mul_sse_mul(quatf_arg0 lhs, quatf_arg1 rhs) RTM_NO_EXCEPT
 {
 	constexpr __m128 control_wzyx = { 1.0f,-1.0f, 1.0f,-1.0f };

--- a/tools/bench/sources/bench_quat_mul_vector3.cpp
+++ b/tools/bench/sources/bench_quat_mul_vector3.cpp
@@ -91,6 +91,7 @@ RTM_FORCE_NOINLINE vector4f RTM_SIMD_CALL quat_mul_vector3_fma(vector4f_arg0 vec
 #if defined(RTM_SSE2_INTRINSICS)
 // Wins on Haswell laptop x64 AVX
 // Wins on Ryzen 2990X desktop VS2017 x64 AVX
+// Wins on Ryzen 2990X desktop clang9 x64 AVX
 RTM_FORCE_NOINLINE vector4f RTM_SIMD_CALL quat_mul_vector3_sse2(vector4f_arg0 vector, quatf_arg1 rotation) RTM_NO_EXCEPT
 {
 	const __m128 inv_rotation = quat_conjugate(rotation);

--- a/tools/bench/sources/bench_quat_mul_vector3.cpp
+++ b/tools/bench/sources/bench_quat_mul_vector3.cpp
@@ -28,7 +28,7 @@
 
 using namespace rtm;
 
-inline vector4f RTM_SIMD_CALL quat_mul_vector3_ref(vector4f_arg0 vector, quatf_arg1 rotation) RTM_NO_EXCEPT
+RTM_FORCE_NOINLINE vector4f RTM_SIMD_CALL quat_mul_vector3_ref(vector4f_arg0 vector, quatf_arg1 rotation) RTM_NO_EXCEPT
 {
 	quatf vector_quat = quat_set_w(vector_to_quat(vector), 0.0f);
 	quatf inv_rotation = quat_conjugate(rotation);
@@ -36,7 +36,7 @@ inline vector4f RTM_SIMD_CALL quat_mul_vector3_ref(vector4f_arg0 vector, quatf_a
 }
 
 #if defined(RTM_FMA_INTRINSICS)
-inline vector4f RTM_SIMD_CALL quat_mul_vector3_fma(vector4f_arg0 vector, quatf_arg1 rotation) RTM_NO_EXCEPT
+RTM_FORCE_NOINLINE vector4f RTM_SIMD_CALL quat_mul_vector3_fma(vector4f_arg0 vector, quatf_arg1 rotation) RTM_NO_EXCEPT
 {
 	const __m128 inv_rotation = quat_conjugate(rotation);
 
@@ -89,7 +89,7 @@ inline vector4f RTM_SIMD_CALL quat_mul_vector3_fma(vector4f_arg0 vector, quatf_a
 #endif
 
 #if defined(RTM_SSE2_INTRINSICS)
-inline vector4f RTM_SIMD_CALL quat_mul_vector3_sse2(vector4f_arg0 vector, quatf_arg1 rotation) RTM_NO_EXCEPT
+RTM_FORCE_NOINLINE vector4f RTM_SIMD_CALL quat_mul_vector3_sse2(vector4f_arg0 vector, quatf_arg1 rotation) RTM_NO_EXCEPT
 {
 	const __m128 inv_rotation = quat_conjugate(rotation);
 
@@ -149,10 +149,13 @@ inline vector4f RTM_SIMD_CALL quat_mul_vector3_sse2(vector4f_arg0 vector, quatf_
 }
 #endif
 
-#if defined(RTM_NEON_INTRINSICS)
-inline vector4f RTM_SIMD_CALL quat_mul_vector3_neon_scalar(vector4f_arg0 vector, quatf_arg1 rotation) RTM_NO_EXCEPT
+RTM_FORCE_NOINLINE vector4f RTM_SIMD_CALL quat_mul_vector3_scalar(vector4f_arg0 vector, quatf_arg1 rotation) RTM_NO_EXCEPT
 {
+#if defined(RTM_NEON_INTRINSICS)
 	const float32x4_t n_rotation = vnegq_f32(rotation);
+#else
+	const vector4f n_rotation = quat_conjugate(rotation);
+#endif
 
 	// temp = quat_mul(inv_rotation, vector_quat)
 	float temp_x;
@@ -195,7 +198,8 @@ inline vector4f RTM_SIMD_CALL quat_mul_vector3_neon_scalar(vector4f_arg0 vector,
 	}
 }
 
-inline vector4f RTM_SIMD_CALL quat_mul_vector3_neon64(vector4f_arg0 vector, quatf_arg1 rotation) RTM_NO_EXCEPT
+#if defined(RTM_NEON_INTRINSICS)
+RTM_FORCE_NOINLINE vector4f RTM_SIMD_CALL quat_mul_vector3_neon64(vector4f_arg0 vector, quatf_arg1 rotation) RTM_NO_EXCEPT
 {
 	const float32x4_t n_rotation = vnegq_f32(rotation);
 
@@ -265,7 +269,7 @@ inline vector4f RTM_SIMD_CALL quat_mul_vector3_neon64(vector4f_arg0 vector, quat
 	}
 }
 
-inline vector4f RTM_SIMD_CALL quat_mul_vector3_neon(vector4f_arg0 vector, quatf_arg1 rotation) RTM_NO_EXCEPT
+RTM_FORCE_NOINLINE vector4f RTM_SIMD_CALL quat_mul_vector3_neon(vector4f_arg0 vector, quatf_arg1 rotation) RTM_NO_EXCEPT
 {
 	alignas(16) constexpr float control_wzyx_f[4] = { 1.0f, -1.0f, 1.0f, -1.0f };
 	alignas(16) constexpr float control_zwxy_f[4] = { 1.0f, 1.0f, -1.0f, -1.0f };

--- a/tools/bench/sources/bench_quat_mul_vector3.cpp
+++ b/tools/bench/sources/bench_quat_mul_vector3.cpp
@@ -89,6 +89,8 @@ RTM_FORCE_NOINLINE vector4f RTM_SIMD_CALL quat_mul_vector3_fma(vector4f_arg0 vec
 #endif
 
 #if defined(RTM_SSE2_INTRINSICS)
+// Wins on Haswell laptop x64 AVX
+// Wins on Ryzen 2990X desktop VS2017 x64 AVX
 RTM_FORCE_NOINLINE vector4f RTM_SIMD_CALL quat_mul_vector3_sse2(vector4f_arg0 vector, quatf_arg1 rotation) RTM_NO_EXCEPT
 {
 	const __m128 inv_rotation = quat_conjugate(rotation);
@@ -149,6 +151,10 @@ RTM_FORCE_NOINLINE vector4f RTM_SIMD_CALL quat_mul_vector3_sse2(vector4f_arg0 ve
 }
 #endif
 
+// Wins on Pixel 3 ARMv7
+// Wins on Pixel 3 ARM64
+// Scalar is much faster. The zipping impl isn't faster here unlike quat_mul for ARM64, it doesn't reduce the instruction
+// count by as much.
 RTM_FORCE_NOINLINE vector4f RTM_SIMD_CALL quat_mul_vector3_scalar(vector4f_arg0 vector, quatf_arg1 rotation) RTM_NO_EXCEPT
 {
 #if defined(RTM_NEON_INTRINSICS)
@@ -269,6 +275,7 @@ RTM_FORCE_NOINLINE vector4f RTM_SIMD_CALL quat_mul_vector3_neon64(vector4f_arg0 
 	}
 }
 
+// Wins on iPad Pro ARM64
 RTM_FORCE_NOINLINE vector4f RTM_SIMD_CALL quat_mul_vector3_neon(vector4f_arg0 vector, quatf_arg1 rotation) RTM_NO_EXCEPT
 {
 	alignas(16) constexpr float control_wzyx_f[4] = { 1.0f, -1.0f, 1.0f, -1.0f };

--- a/tools/bench/sources/bench_quat_mul_vector3.cpp
+++ b/tools/bench/sources/bench_quat_mul_vector3.cpp
@@ -339,22 +339,93 @@ inline vector4f RTM_SIMD_CALL quat_mul_vector3_neon(vector4f_arg0 vector, quatf_
 static void bm_quat_mul_vector3_ref(benchmark::State& state)
 {
 	vector4f v0 = vector_set(12.0f, 32.0f, -2.0f);
+	vector4f v1 = vector_set(12.0f, 32.0f, -2.0f);
+	vector4f v2 = vector_set(12.0f, 32.0f, -2.0f);
+	vector4f v3 = vector_set(12.0f, 32.0f, -2.0f);
 	quatf q0 = quat_identity();
+	quatf q1 = quat_identity();
+	quatf q2 = quat_identity();
+	quatf q3 = quat_identity();
 
 	for (auto _ : state)
-		benchmark::DoNotOptimize(v0 = quat_mul_vector3_ref(q0, v0));
+	{
+		v0 = quat_mul_vector3_ref(v0, q0);
+		v1 = quat_mul_vector3_ref(v1, q1);
+		v2 = quat_mul_vector3_ref(v2, q2);
+		v3 = quat_mul_vector3_ref(v3, q3);
+	}
+
+	benchmark::DoNotOptimize(q0);
+	benchmark::DoNotOptimize(q1);
+	benchmark::DoNotOptimize(q2);
+	benchmark::DoNotOptimize(q3);
+	benchmark::DoNotOptimize(v0);
+	benchmark::DoNotOptimize(v1);
+	benchmark::DoNotOptimize(v2);
+	benchmark::DoNotOptimize(v3);
 }
 
 BENCHMARK(bm_quat_mul_vector3_ref);
+
+static void bm_quat_mul_vector3_scalar(benchmark::State& state)
+{
+	vector4f v0 = vector_set(12.0f, 32.0f, -2.0f);
+	vector4f v1 = vector_set(12.0f, 32.0f, -2.0f);
+	vector4f v2 = vector_set(12.0f, 32.0f, -2.0f);
+	vector4f v3 = vector_set(12.0f, 32.0f, -2.0f);
+	quatf q0 = quat_identity();
+	quatf q1 = quat_identity();
+	quatf q2 = quat_identity();
+	quatf q3 = quat_identity();
+
+	for (auto _ : state)
+	{
+		v0 = quat_mul_vector3_scalar(v0, q0);
+		v1 = quat_mul_vector3_scalar(v1, q1);
+		v2 = quat_mul_vector3_scalar(v2, q2);
+		v3 = quat_mul_vector3_scalar(v3, q3);
+	}
+
+	benchmark::DoNotOptimize(q0);
+	benchmark::DoNotOptimize(q1);
+	benchmark::DoNotOptimize(q2);
+	benchmark::DoNotOptimize(q3);
+	benchmark::DoNotOptimize(v0);
+	benchmark::DoNotOptimize(v1);
+	benchmark::DoNotOptimize(v2);
+	benchmark::DoNotOptimize(v3);
+}
+
+BENCHMARK(bm_quat_mul_vector3_scalar);
 
 #if defined(RTM_FMA_INTRINSICS)
 static void bm_quat_mul_vector3_fma(benchmark::State& state)
 {
 	vector4f v0 = vector_set(12.0f, 32.0f, -2.0f);
+	vector4f v1 = vector_set(12.0f, 32.0f, -2.0f);
+	vector4f v2 = vector_set(12.0f, 32.0f, -2.0f);
+	vector4f v3 = vector_set(12.0f, 32.0f, -2.0f);
 	quatf q0 = quat_identity();
+	quatf q1 = quat_identity();
+	quatf q2 = quat_identity();
+	quatf q3 = quat_identity();
 
 	for (auto _ : state)
-		benchmark::DoNotOptimize(v0 = quat_mul_vector3_fma(q0, v0));
+	{
+		v0 = quat_mul_vector3_fma(v0, q0);
+		v1 = quat_mul_vector3_fma(v1, q1);
+		v2 = quat_mul_vector3_fma(v2, q2);
+		v3 = quat_mul_vector3_fma(v3, q3);
+	}
+
+	benchmark::DoNotOptimize(q0);
+	benchmark::DoNotOptimize(q1);
+	benchmark::DoNotOptimize(q2);
+	benchmark::DoNotOptimize(q3);
+	benchmark::DoNotOptimize(v0);
+	benchmark::DoNotOptimize(v1);
+	benchmark::DoNotOptimize(v2);
+	benchmark::DoNotOptimize(v3);
 }
 
 BENCHMARK(bm_quat_mul_vector3_fma);
@@ -364,34 +435,63 @@ BENCHMARK(bm_quat_mul_vector3_fma);
 static void bm_quat_mul_vector3_sse2(benchmark::State& state)
 {
 	vector4f v0 = vector_set(12.0f, 32.0f, -2.0f);
+	vector4f v1 = vector_set(12.0f, 32.0f, -2.0f);
+	vector4f v2 = vector_set(12.0f, 32.0f, -2.0f);
+	vector4f v3 = vector_set(12.0f, 32.0f, -2.0f);
 	quatf q0 = quat_identity();
+	quatf q1 = quat_identity();
+	quatf q2 = quat_identity();
+	quatf q3 = quat_identity();
 
 	for (auto _ : state)
-		benchmark::DoNotOptimize(v0 = quat_mul_vector3_sse2(q0, v0));
+	{
+		v0 = quat_mul_vector3_sse2(v0, q0);
+		v1 = quat_mul_vector3_sse2(v1, q1);
+		v2 = quat_mul_vector3_sse2(v2, q2);
+		v3 = quat_mul_vector3_sse2(v3, q3);
+	}
+
+	benchmark::DoNotOptimize(q0);
+	benchmark::DoNotOptimize(q1);
+	benchmark::DoNotOptimize(q2);
+	benchmark::DoNotOptimize(q3);
+	benchmark::DoNotOptimize(v0);
+	benchmark::DoNotOptimize(v1);
+	benchmark::DoNotOptimize(v2);
+	benchmark::DoNotOptimize(v3);
 }
 
 BENCHMARK(bm_quat_mul_vector3_sse2);
 #endif
 
 #if defined(RTM_NEON_INTRINSICS)
-static void bm_quat_mul_vector3_neon_scalar(benchmark::State& state)
-{
-	vector4f v0 = vector_set(12.0f, 32.0f, -2.0f);
-	quatf q0 = quat_identity();
-
-	for (auto _ : state)
-		benchmark::DoNotOptimize(v0 = quat_mul_vector3_neon_scalar(q0, v0));
-}
-
-BENCHMARK(bm_quat_mul_vector3_neon_scalar);
-
 static void bm_quat_mul_vector3_neon64(benchmark::State& state)
 {
 	vector4f v0 = vector_set(12.0f, 32.0f, -2.0f);
+	vector4f v1 = vector_set(12.0f, 32.0f, -2.0f);
+	vector4f v2 = vector_set(12.0f, 32.0f, -2.0f);
+	vector4f v3 = vector_set(12.0f, 32.0f, -2.0f);
 	quatf q0 = quat_identity();
+	quatf q1 = quat_identity();
+	quatf q2 = quat_identity();
+	quatf q3 = quat_identity();
 
 	for (auto _ : state)
-		benchmark::DoNotOptimize(v0 = quat_mul_vector3_neon64(q0, v0));
+	{
+		v0 = quat_mul_vector3_neon64(v0, q0);
+		v1 = quat_mul_vector3_neon64(v1, q1);
+		v2 = quat_mul_vector3_neon64(v2, q2);
+		v3 = quat_mul_vector3_neon64(v3, q3);
+	}
+
+	benchmark::DoNotOptimize(q0);
+	benchmark::DoNotOptimize(q1);
+	benchmark::DoNotOptimize(q2);
+	benchmark::DoNotOptimize(q3);
+	benchmark::DoNotOptimize(v0);
+	benchmark::DoNotOptimize(v1);
+	benchmark::DoNotOptimize(v2);
+	benchmark::DoNotOptimize(v3);
 }
 
 BENCHMARK(bm_quat_mul_vector3_neon64);
@@ -399,10 +499,30 @@ BENCHMARK(bm_quat_mul_vector3_neon64);
 static void bm_quat_mul_vector3_neon(benchmark::State& state)
 {
 	vector4f v0 = vector_set(12.0f, 32.0f, -2.0f);
+	vector4f v1 = vector_set(12.0f, 32.0f, -2.0f);
+	vector4f v2 = vector_set(12.0f, 32.0f, -2.0f);
+	vector4f v3 = vector_set(12.0f, 32.0f, -2.0f);
 	quatf q0 = quat_identity();
+	quatf q1 = quat_identity();
+	quatf q2 = quat_identity();
+	quatf q3 = quat_identity();
 
 	for (auto _ : state)
-		benchmark::DoNotOptimize(v0 = quat_mul_vector3_neon(q0, v0));
+	{
+		v0 = quat_mul_vector3_neon(v0, q0);
+		v1 = quat_mul_vector3_neon(v1, q1);
+		v2 = quat_mul_vector3_neon(v2, q2);
+		v3 = quat_mul_vector3_neon(v3, q3);
+	}
+
+	benchmark::DoNotOptimize(q0);
+	benchmark::DoNotOptimize(q1);
+	benchmark::DoNotOptimize(q2);
+	benchmark::DoNotOptimize(q3);
+	benchmark::DoNotOptimize(v0);
+	benchmark::DoNotOptimize(v1);
+	benchmark::DoNotOptimize(v2);
+	benchmark::DoNotOptimize(v3);
 }
 
 BENCHMARK(bm_quat_mul_vector3_neon);

--- a/tools/bench/sources/bench_qvv_mul.cpp
+++ b/tools/bench/sources/bench_qvv_mul.cpp
@@ -96,9 +96,19 @@ static void bm_qvv_mul_ref(benchmark::State& state)
 {
 	qvvf t0 = qvv_identity();
 	qvvf t1 = qvv_set(quat_identity(), vector_zero(), vector_set(-1.0f));
+	qvvf t2 = qvv_identity();
+	qvvf t3 = qvv_set(quat_identity(), vector_zero(), vector_set(-1.0f));
 
 	for (auto _ : state)
-		benchmark::DoNotOptimize(t0 = qvv_mul_ref(t0, t1));
+	{
+		t0 = qvv_mul_ref(t0, t1);
+		t2 = qvv_mul_ref(t2, t3);
+	}
+
+	benchmark::DoNotOptimize(t0);
+	benchmark::DoNotOptimize(t1);
+	benchmark::DoNotOptimize(t2);
+	benchmark::DoNotOptimize(t3);
 }
 
 BENCHMARK(bm_qvv_mul_ref);
@@ -108,9 +118,19 @@ static void bm_qvv_mul_sse2(benchmark::State& state)
 {
 	qvvf t0 = qvv_identity();
 	qvvf t1 = qvv_set(quat_identity(), vector_zero(), vector_set(-1.0f));
+	qvvf t2 = qvv_identity();
+	qvvf t3 = qvv_set(quat_identity(), vector_zero(), vector_set(-1.0f));
 
 	for (auto _ : state)
-		benchmark::DoNotOptimize(t0 = qvv_mul_sse2(t0, t1));
+	{
+		t0 = qvv_mul_sse2(t0, t1);
+		t2 = qvv_mul_sse2(t2, t3);
+	}
+
+	benchmark::DoNotOptimize(t0);
+	benchmark::DoNotOptimize(t1);
+	benchmark::DoNotOptimize(t2);
+	benchmark::DoNotOptimize(t3);
 }
 
 BENCHMARK(bm_qvv_mul_sse2);

--- a/tools/bench/sources/bench_qvv_mul.cpp
+++ b/tools/bench/sources/bench_qvv_mul.cpp
@@ -59,6 +59,7 @@ RTM_FORCE_NOINLINE qvvf RTM_SIMD_CALL qvv_mul_ref(qvvf_arg0 lhs, qvvf_arg1 rhs) 
 }
 
 #if defined(RTM_SSE2_INTRINSICS)
+// Wins on Haswell laptop x64 AVX
 // Wins on Ryzen 2990X desktop VS2017 x64 AVX
 // Wins on Ryzen 2990X desktop clang9 x64 AVX
 RTM_FORCE_NOINLINE qvvf RTM_SIMD_CALL qvv_mul_sse2(qvvf_arg0 lhs, qvvf_arg1 rhs) RTM_NO_EXCEPT

--- a/tools/bench/sources/bench_qvv_mul.cpp
+++ b/tools/bench/sources/bench_qvv_mul.cpp
@@ -59,6 +59,7 @@ RTM_FORCE_NOINLINE qvvf RTM_SIMD_CALL qvv_mul_ref(qvvf_arg0 lhs, qvvf_arg1 rhs) 
 }
 
 #if defined(RTM_SSE2_INTRINSICS)
+// Wins on Ryzen 2990X desktop VS2017 x64 AVX
 RTM_FORCE_NOINLINE qvvf RTM_SIMD_CALL qvv_mul_sse2(qvvf_arg0 lhs, qvvf_arg1 rhs) RTM_NO_EXCEPT
 {
 	const vector4f min_scale = vector_min(lhs.scale, rhs.scale);

--- a/tools/bench/sources/bench_qvv_mul.cpp
+++ b/tools/bench/sources/bench_qvv_mul.cpp
@@ -60,6 +60,7 @@ RTM_FORCE_NOINLINE qvvf RTM_SIMD_CALL qvv_mul_ref(qvvf_arg0 lhs, qvvf_arg1 rhs) 
 
 #if defined(RTM_SSE2_INTRINSICS)
 // Wins on Ryzen 2990X desktop VS2017 x64 AVX
+// Wins on Ryzen 2990X desktop clang9 x64 AVX
 RTM_FORCE_NOINLINE qvvf RTM_SIMD_CALL qvv_mul_sse2(qvvf_arg0 lhs, qvvf_arg1 rhs) RTM_NO_EXCEPT
 {
 	const vector4f min_scale = vector_min(lhs.scale, rhs.scale);

--- a/tools/bench/sources/bench_qvv_mul.cpp
+++ b/tools/bench/sources/bench_qvv_mul.cpp
@@ -28,7 +28,7 @@
 
 using namespace rtm;
 
-inline qvvf RTM_SIMD_CALL qvv_mul_ref(qvvf_arg0 lhs, qvvf_arg1 rhs) RTM_NO_EXCEPT
+RTM_FORCE_NOINLINE qvvf RTM_SIMD_CALL qvv_mul_ref(qvvf_arg0 lhs, qvvf_arg1 rhs) RTM_NO_EXCEPT
 {
 	const vector4f min_scale = vector_min(lhs.scale, rhs.scale);
 	const vector4f scale = vector_mul(lhs.scale, rhs.scale);
@@ -59,7 +59,7 @@ inline qvvf RTM_SIMD_CALL qvv_mul_ref(qvvf_arg0 lhs, qvvf_arg1 rhs) RTM_NO_EXCEP
 }
 
 #if defined(RTM_SSE2_INTRINSICS)
-inline qvvf RTM_SIMD_CALL qvv_mul_sse2(qvvf_arg0 lhs, qvvf_arg1 rhs) RTM_NO_EXCEPT
+RTM_FORCE_NOINLINE qvvf RTM_SIMD_CALL qvv_mul_sse2(qvvf_arg0 lhs, qvvf_arg1 rhs) RTM_NO_EXCEPT
 {
 	const vector4f min_scale = vector_min(lhs.scale, rhs.scale);
 	const vector4f scale = vector_mul(lhs.scale, rhs.scale);

--- a/tools/bench/sources/bench_scalar_abs.cpp
+++ b/tools/bench/sources/bench_scalar_abs.cpp
@@ -38,6 +38,7 @@ RTM_FORCE_NOINLINE float RTM_SIMD_CALL scalar_abs_scalar(float input) RTM_NO_EXC
 }
 
 #if defined(RTM_SSE2_INTRINSICS)
+// Wins on Ryzen 2990X desktop clang9 x64 AVX
 RTM_FORCE_NOINLINE float RTM_SIMD_CALL vector_abs_sse2_and(float input) RTM_NO_EXCEPT
 {
 #if defined(_MSC_VER)

--- a/tools/bench/sources/bench_scalar_abs.cpp
+++ b/tools/bench/sources/bench_scalar_abs.cpp
@@ -39,7 +39,7 @@ RTM_FORCE_NOINLINE float RTM_SIMD_CALL scalar_abs_scalar(float input) RTM_NO_EXC
 
 #if defined(RTM_SSE2_INTRINSICS)
 // Wins on Ryzen 2990X desktop clang9 x64 AVX
-RTM_FORCE_NOINLINE float RTM_SIMD_CALL vector_abs_sse2_and(float input) RTM_NO_EXCEPT
+RTM_FORCE_NOINLINE float RTM_SIMD_CALL scalar_abs_sse2_and(float input) RTM_NO_EXCEPT
 {
 #if defined(_MSC_VER)
 	constexpr __m128i masks = { 0xFFU, 0xFFU, 0xFFU, 0x7FU, 0xFFU, 0xFFU, 0xFFU, 0x7FU, 0xFFU, 0xFFU, 0xFFU, 0x7FU, 0xFFU, 0xFFU, 0xFFU, 0x7FU };
@@ -99,14 +99,14 @@ static void bm_scalar_abs_sse2_and(benchmark::State& state)
 
 	for (auto _ : state)
 	{
-		f0 = vector_abs_sse2_and(f0);
-		f1 = vector_abs_sse2_and(f1);
-		f2 = vector_abs_sse2_and(f2);
-		f3 = vector_abs_sse2_and(f3);
-		f4 = vector_abs_sse2_and(f4);
-		f5 = vector_abs_sse2_and(f5);
-		f6 = vector_abs_sse2_and(f6);
-		f7 = vector_abs_sse2_and(f7);
+		f0 = scalar_abs_sse2_and(f0);
+		f1 = scalar_abs_sse2_and(f1);
+		f2 = scalar_abs_sse2_and(f2);
+		f3 = scalar_abs_sse2_and(f3);
+		f4 = scalar_abs_sse2_and(f4);
+		f5 = scalar_abs_sse2_and(f5);
+		f6 = scalar_abs_sse2_and(f6);
+		f7 = scalar_abs_sse2_and(f7);
 	}
 
 	benchmark::DoNotOptimize(f0);

--- a/tools/bench/sources/bench_scalar_abs.cpp
+++ b/tools/bench/sources/bench_scalar_abs.cpp
@@ -38,6 +38,8 @@ RTM_FORCE_NOINLINE float RTM_SIMD_CALL scalar_abs_scalar(float input) RTM_NO_EXC
 }
 
 #if defined(RTM_SSE2_INTRINSICS)
+// Wins on Haswell laptop x64 AVX
+// Both impl are about the same.
 // Wins on Ryzen 2990X desktop clang9 x64 AVX
 RTM_FORCE_NOINLINE float RTM_SIMD_CALL scalar_abs_sse2_and(float input) RTM_NO_EXCEPT
 {

--- a/tools/bench/sources/bench_scalar_abs.cpp
+++ b/tools/bench/sources/bench_scalar_abs.cpp
@@ -28,13 +28,13 @@
 
 using namespace rtm;
 
-inline float RTM_SIMD_CALL scalar_abs_scalar(float input) RTM_NO_EXCEPT
+RTM_FORCE_NOINLINE float RTM_SIMD_CALL scalar_abs_scalar(float input) RTM_NO_EXCEPT
 {
 	return std::fabs(input);
 }
 
 #if defined(RTM_SSE2_INTRINSICS)
-inline float RTM_SIMD_CALL vector_abs_sse2_and(float input) RTM_NO_EXCEPT
+RTM_FORCE_NOINLINE float RTM_SIMD_CALL vector_abs_sse2_and(float input) RTM_NO_EXCEPT
 {
 #if defined(_MSC_VER)
 	constexpr __m128i masks = { 0xFFU, 0xFFU, 0xFFU, 0x7FU, 0xFFU, 0xFFU, 0xFFU, 0x7FU, 0xFFU, 0xFFU, 0xFFU, 0x7FU, 0xFFU, 0xFFU, 0xFFU, 0x7FU };

--- a/tools/bench/sources/bench_scalar_abs.cpp
+++ b/tools/bench/sources/bench_scalar_abs.cpp
@@ -28,6 +28,10 @@
 
 using namespace rtm;
 
+// Wins on Ryzen 2990X desktop VS2017 x64 AVX
+// Oddly consistently faster despite the fact that the scalar impl is 3 instructions
+// and converts to/from double while sse2_and is 2 instructions (a needless shuffle + and).
+// It seems the functions are so short that the timing is dominated by something else.
 RTM_FORCE_NOINLINE float RTM_SIMD_CALL scalar_abs_scalar(float input) RTM_NO_EXCEPT
 {
 	return std::fabs(input);

--- a/tools/bench/sources/bench_scalar_abs.cpp
+++ b/tools/bench/sources/bench_scalar_abs.cpp
@@ -48,9 +48,34 @@ inline float RTM_SIMD_CALL vector_abs_sse2_and(float input) RTM_NO_EXCEPT
 static void bm_scalar_abs_scalar(benchmark::State& state)
 {
 	float f0 = -123.134f;
+	float f1 = -123.134f;
+	float f2 = -123.134f;
+	float f3 = -123.134f;
+	float f4 = -123.134f;
+	float f5 = -123.134f;
+	float f6 = -123.134f;
+	float f7 = -123.134f;
 
 	for (auto _ : state)
-		benchmark::DoNotOptimize(f0 = scalar_abs_scalar(f0));
+	{
+		f0 = scalar_abs_scalar(f0);
+		f1 = scalar_abs_scalar(f1);
+		f2 = scalar_abs_scalar(f2);
+		f3 = scalar_abs_scalar(f3);
+		f4 = scalar_abs_scalar(f4);
+		f5 = scalar_abs_scalar(f5);
+		f6 = scalar_abs_scalar(f6);
+		f7 = scalar_abs_scalar(f7);
+	}
+
+	benchmark::DoNotOptimize(f0);
+	benchmark::DoNotOptimize(f1);
+	benchmark::DoNotOptimize(f2);
+	benchmark::DoNotOptimize(f3);
+	benchmark::DoNotOptimize(f4);
+	benchmark::DoNotOptimize(f5);
+	benchmark::DoNotOptimize(f6);
+	benchmark::DoNotOptimize(f7);
 }
 
 BENCHMARK(bm_scalar_abs_scalar);
@@ -59,9 +84,34 @@ BENCHMARK(bm_scalar_abs_scalar);
 static void bm_scalar_abs_sse2_and(benchmark::State& state)
 {
 	float f0 = -123.134f;
+	float f1 = -123.134f;
+	float f2 = -123.134f;
+	float f3 = -123.134f;
+	float f4 = -123.134f;
+	float f5 = -123.134f;
+	float f6 = -123.134f;
+	float f7 = -123.134f;
 
 	for (auto _ : state)
-		benchmark::DoNotOptimize(f0 = vector_abs_sse2_and(f0));
+	{
+		f0 = vector_abs_sse2_and(f0);
+		f1 = vector_abs_sse2_and(f1);
+		f2 = vector_abs_sse2_and(f2);
+		f3 = vector_abs_sse2_and(f3);
+		f4 = vector_abs_sse2_and(f4);
+		f5 = vector_abs_sse2_and(f5);
+		f6 = vector_abs_sse2_and(f6);
+		f7 = vector_abs_sse2_and(f7);
+	}
+
+	benchmark::DoNotOptimize(f0);
+	benchmark::DoNotOptimize(f1);
+	benchmark::DoNotOptimize(f2);
+	benchmark::DoNotOptimize(f3);
+	benchmark::DoNotOptimize(f4);
+	benchmark::DoNotOptimize(f5);
+	benchmark::DoNotOptimize(f6);
+	benchmark::DoNotOptimize(f7);
 }
 
 BENCHMARK(bm_scalar_abs_sse2_and);

--- a/tools/bench/sources/bench_vector_abs.cpp
+++ b/tools/bench/sources/bench_vector_abs.cpp
@@ -39,6 +39,8 @@ RTM_FORCE_NOINLINE vector4f RTM_SIMD_CALL vector_abs_sse2_maxsub(vector4f_arg0 i
 	return vector_max(vector_sub(_mm_setzero_ps(), input), input);
 }
 
+// Wins on Haswell laptop x64 AVX
+// Wins on Ryzen 2990X desktop VS2017 x64 AVX
 RTM_FORCE_NOINLINE vector4f RTM_SIMD_CALL vector_abs_sse2_and(vector4f_arg0 input) RTM_NO_EXCEPT
 {
 #if defined(_MSC_VER)

--- a/tools/bench/sources/bench_vector_abs.cpp
+++ b/tools/bench/sources/bench_vector_abs.cpp
@@ -41,6 +41,7 @@ RTM_FORCE_NOINLINE vector4f RTM_SIMD_CALL vector_abs_sse2_maxsub(vector4f_arg0 i
 
 // Wins on Haswell laptop x64 AVX
 // Wins on Ryzen 2990X desktop VS2017 x64 AVX
+// Wins on Ryzen 2990X desktop clang9 x64 AVX
 RTM_FORCE_NOINLINE vector4f RTM_SIMD_CALL vector_abs_sse2_and(vector4f_arg0 input) RTM_NO_EXCEPT
 {
 #if defined(_MSC_VER)

--- a/tools/bench/sources/bench_vector_abs.cpp
+++ b/tools/bench/sources/bench_vector_abs.cpp
@@ -53,20 +53,71 @@ inline vector4f RTM_SIMD_CALL vector_abs_sse2_and(vector4f_arg0 input) RTM_NO_EX
 static void bm_vector_abs_scalar(benchmark::State& state)
 {
 	vector4f v0 = vector_set(-1.0f, 1.0f, -2.0f, -123.134f);
+	vector4f v1 = vector_set(-1.0f, 1.0f, -2.0f, -123.134f);
+	vector4f v2 = vector_set(-1.0f, 1.0f, -2.0f, -123.134f);
+	vector4f v3 = vector_set(-1.0f, 1.0f, -2.0f, -123.134f);
+	vector4f v4 = vector_set(-1.0f, 1.0f, -2.0f, -123.134f);
+	vector4f v5 = vector_set(-1.0f, 1.0f, -2.0f, -123.134f);
+	vector4f v6 = vector_set(-1.0f, 1.0f, -2.0f, -123.134f);
+	vector4f v7 = vector_set(-1.0f, 1.0f, -2.0f, -123.134f);
 
 	for (auto _ : state)
-		benchmark::DoNotOptimize(v0 = vector_abs_scalar(v0));
+	{
+		v0 = vector_abs_scalar(v0);
+		v1 = vector_abs_scalar(v1);
+		v2 = vector_abs_scalar(v2);
+		v3 = vector_abs_scalar(v3);
+		v4 = vector_abs_scalar(v4);
+		v5 = vector_abs_scalar(v5);
+		v6 = vector_abs_scalar(v6);
+		v7 = vector_abs_scalar(v7);
+	}
+
+	benchmark::DoNotOptimize(v0);
+	benchmark::DoNotOptimize(v1);
+	benchmark::DoNotOptimize(v2);
+	benchmark::DoNotOptimize(v3);
+	benchmark::DoNotOptimize(v4);
+	benchmark::DoNotOptimize(v5);
+	benchmark::DoNotOptimize(v6);
+	benchmark::DoNotOptimize(v7);
 }
 
 BENCHMARK(bm_vector_abs_scalar);
 
 #if defined(RTM_SSE2_INTRINSICS)
+// Wins on Ryzen 2990X desktop VS2017 x64 AVX
 static void bm_vector_abs_sse2_maxsub(benchmark::State& state)
 {
 	vector4f v0 = vector_set(-1.0f, 1.0f, -2.0f, -123.134f);
+	vector4f v1 = vector_set(-1.0f, 1.0f, -2.0f, -123.134f);
+	vector4f v2 = vector_set(-1.0f, 1.0f, -2.0f, -123.134f);
+	vector4f v3 = vector_set(-1.0f, 1.0f, -2.0f, -123.134f);
+	vector4f v4 = vector_set(-1.0f, 1.0f, -2.0f, -123.134f);
+	vector4f v5 = vector_set(-1.0f, 1.0f, -2.0f, -123.134f);
+	vector4f v6 = vector_set(-1.0f, 1.0f, -2.0f, -123.134f);
+	vector4f v7 = vector_set(-1.0f, 1.0f, -2.0f, -123.134f);
 
 	for (auto _ : state)
-		benchmark::DoNotOptimize(v0 = vector_abs_sse2_maxsub(v0));
+	{
+		v0 = vector_abs_sse2_maxsub(v0);
+		v1 = vector_abs_sse2_maxsub(v1);
+		v2 = vector_abs_sse2_maxsub(v2);
+		v3 = vector_abs_sse2_maxsub(v3);
+		v4 = vector_abs_sse2_maxsub(v4);
+		v5 = vector_abs_sse2_maxsub(v5);
+		v6 = vector_abs_sse2_maxsub(v6);
+		v7 = vector_abs_sse2_maxsub(v7);
+	}
+
+	benchmark::DoNotOptimize(v0);
+	benchmark::DoNotOptimize(v1);
+	benchmark::DoNotOptimize(v2);
+	benchmark::DoNotOptimize(v3);
+	benchmark::DoNotOptimize(v4);
+	benchmark::DoNotOptimize(v5);
+	benchmark::DoNotOptimize(v6);
+	benchmark::DoNotOptimize(v7);
 }
 
 BENCHMARK(bm_vector_abs_sse2_maxsub);
@@ -74,9 +125,34 @@ BENCHMARK(bm_vector_abs_sse2_maxsub);
 static void bm_vector_abs_sse2_and(benchmark::State& state)
 {
 	vector4f v0 = vector_set(-1.0f, 1.0f, -2.0f, -123.134f);
+	vector4f v1 = vector_set(-1.0f, 1.0f, -2.0f, -123.134f);
+	vector4f v2 = vector_set(-1.0f, 1.0f, -2.0f, -123.134f);
+	vector4f v3 = vector_set(-1.0f, 1.0f, -2.0f, -123.134f);
+	vector4f v4 = vector_set(-1.0f, 1.0f, -2.0f, -123.134f);
+	vector4f v5 = vector_set(-1.0f, 1.0f, -2.0f, -123.134f);
+	vector4f v6 = vector_set(-1.0f, 1.0f, -2.0f, -123.134f);
+	vector4f v7 = vector_set(-1.0f, 1.0f, -2.0f, -123.134f);
 
 	for (auto _ : state)
-		benchmark::DoNotOptimize(v0 = vector_abs_sse2_and(v0));
+	{
+		v0 = vector_abs_sse2_and(v0);
+		v1 = vector_abs_sse2_and(v1);
+		v2 = vector_abs_sse2_and(v2);
+		v3 = vector_abs_sse2_and(v3);
+		v4 = vector_abs_sse2_and(v4);
+		v5 = vector_abs_sse2_and(v5);
+		v6 = vector_abs_sse2_and(v6);
+		v7 = vector_abs_sse2_and(v7);
+	}
+
+	benchmark::DoNotOptimize(v0);
+	benchmark::DoNotOptimize(v1);
+	benchmark::DoNotOptimize(v2);
+	benchmark::DoNotOptimize(v3);
+	benchmark::DoNotOptimize(v4);
+	benchmark::DoNotOptimize(v5);
+	benchmark::DoNotOptimize(v6);
+	benchmark::DoNotOptimize(v7);
 }
 
 BENCHMARK(bm_vector_abs_sse2_and);

--- a/tools/bench/sources/bench_vector_abs.cpp
+++ b/tools/bench/sources/bench_vector_abs.cpp
@@ -28,18 +28,18 @@
 
 using namespace rtm;
 
-inline vector4f RTM_SIMD_CALL vector_abs_scalar(vector4f_arg0 input) RTM_NO_EXCEPT
+RTM_FORCE_NOINLINE vector4f RTM_SIMD_CALL vector_abs_scalar(vector4f_arg0 input) RTM_NO_EXCEPT
 {
 	return vector_set(scalar_abs(vector_get_x(input)), scalar_abs(vector_get_y(input)), scalar_abs(vector_get_z(input)), scalar_abs(vector_get_w(input)));
 }
 
 #if defined(RTM_SSE2_INTRINSICS)
-inline vector4f RTM_SIMD_CALL vector_abs_sse2_maxsub(vector4f_arg0 input) RTM_NO_EXCEPT
+RTM_FORCE_NOINLINE vector4f RTM_SIMD_CALL vector_abs_sse2_maxsub(vector4f_arg0 input) RTM_NO_EXCEPT
 {
 	return vector_max(vector_sub(_mm_setzero_ps(), input), input);
 }
 
-inline vector4f RTM_SIMD_CALL vector_abs_sse2_and(vector4f_arg0 input) RTM_NO_EXCEPT
+RTM_FORCE_NOINLINE vector4f RTM_SIMD_CALL vector_abs_sse2_and(vector4f_arg0 input) RTM_NO_EXCEPT
 {
 #if defined(_MSC_VER)
 	constexpr __m128i masks = { 0xFFU, 0xFFU, 0xFFU, 0x7FU, 0xFFU, 0xFFU, 0xFFU, 0x7FU, 0xFFU, 0xFFU, 0xFFU, 0x7FU, 0xFFU, 0xFFU, 0xFFU, 0x7FU };

--- a/tools/bench/sources/bench_vector_sign.cpp
+++ b/tools/bench/sources/bench_vector_sign.cpp
@@ -38,6 +38,7 @@ RTM_FORCE_NOINLINE vector4f RTM_SIMD_CALL vector_sign_ref(vector4f_arg0 input) R
 
 #if defined(RTM_SSE2_INTRINSICS)
 // Wins on Haswell laptop x64 AVX
+// Wins on Ryzen 2990X desktop clang9 x64 AVX
 RTM_FORCE_NOINLINE vector4f RTM_SIMD_CALL vector_sign_sse2(vector4f_arg0 input) RTM_NO_EXCEPT
 {
 	constexpr __m128 signs = { -0.0f, -0.0f, -0.0f, -0.0f };

--- a/tools/bench/sources/bench_vector_sign.cpp
+++ b/tools/bench/sources/bench_vector_sign.cpp
@@ -28,14 +28,14 @@
 
 using namespace rtm;
 
-inline vector4f RTM_SIMD_CALL vector_sign_ref(vector4f_arg0 input) RTM_NO_EXCEPT
+RTM_FORCE_NOINLINE vector4f RTM_SIMD_CALL vector_sign_ref(vector4f_arg0 input) RTM_NO_EXCEPT
 {
 	const mask4i mask = vector_greater_equal(input, vector_zero());
 	return vector_select(mask, vector_set(1.0f), vector_set(-1.0f));
 }
 
 #if defined(RTM_SSE2_INTRINSICS)
-inline vector4f RTM_SIMD_CALL vector_sign_sse2(vector4f_arg0 input) RTM_NO_EXCEPT
+RTM_FORCE_NOINLINE vector4f RTM_SIMD_CALL vector_sign_sse2(vector4f_arg0 input) RTM_NO_EXCEPT
 {
 	constexpr __m128 signs = { -0.0f, -0.0f, -0.0f, -0.0f };
 	constexpr __m128 one = { 1.0f, 1.0f, 1.0f, 1.0f };

--- a/tools/bench/sources/bench_vector_sign.cpp
+++ b/tools/bench/sources/bench_vector_sign.cpp
@@ -47,9 +47,34 @@ inline vector4f RTM_SIMD_CALL vector_sign_sse2(vector4f_arg0 input) RTM_NO_EXCEP
 static void bm_vector_sign_ref(benchmark::State& state)
 {
 	vector4f v0 = vector_set(-1.0f, 1.0f, -2.0f, -123.134f);
+	vector4f v1 = vector_set(-1.0f, 1.0f, -2.0f, -123.134f);
+	vector4f v2 = vector_set(-1.0f, 1.0f, -2.0f, -123.134f);
+	vector4f v3 = vector_set(-1.0f, 1.0f, -2.0f, -123.134f);
+	vector4f v4 = vector_set(-1.0f, 1.0f, -2.0f, -123.134f);
+	vector4f v5 = vector_set(-1.0f, 1.0f, -2.0f, -123.134f);
+	vector4f v6 = vector_set(-1.0f, 1.0f, -2.0f, -123.134f);
+	vector4f v7 = vector_set(-1.0f, 1.0f, -2.0f, -123.134f);
 
 	for (auto _ : state)
-		benchmark::DoNotOptimize(v0 = vector_sign_ref(v0));
+	{
+		v0 = vector_sign_ref(v0);
+		v1 = vector_sign_ref(v1);
+		v2 = vector_sign_ref(v2);
+		v3 = vector_sign_ref(v3);
+		v4 = vector_sign_ref(v4);
+		v5 = vector_sign_ref(v5);
+		v6 = vector_sign_ref(v6);
+		v7 = vector_sign_ref(v7);
+	}
+
+	benchmark::DoNotOptimize(v0);
+	benchmark::DoNotOptimize(v1);
+	benchmark::DoNotOptimize(v2);
+	benchmark::DoNotOptimize(v3);
+	benchmark::DoNotOptimize(v4);
+	benchmark::DoNotOptimize(v5);
+	benchmark::DoNotOptimize(v6);
+	benchmark::DoNotOptimize(v7);
 }
 
 BENCHMARK(bm_vector_sign_ref);
@@ -58,9 +83,34 @@ BENCHMARK(bm_vector_sign_ref);
 static void bm_vector_sign_sse2(benchmark::State& state)
 {
 	vector4f v0 = vector_set(-1.0f, 1.0f, -2.0f, -123.134f);
+	vector4f v1 = vector_set(-1.0f, 1.0f, -2.0f, -123.134f);
+	vector4f v2 = vector_set(-1.0f, 1.0f, -2.0f, -123.134f);
+	vector4f v3 = vector_set(-1.0f, 1.0f, -2.0f, -123.134f);
+	vector4f v4 = vector_set(-1.0f, 1.0f, -2.0f, -123.134f);
+	vector4f v5 = vector_set(-1.0f, 1.0f, -2.0f, -123.134f);
+	vector4f v6 = vector_set(-1.0f, 1.0f, -2.0f, -123.134f);
+	vector4f v7 = vector_set(-1.0f, 1.0f, -2.0f, -123.134f);
 
 	for (auto _ : state)
-		benchmark::DoNotOptimize(v0 = vector_sign_sse2(v0));
+	{
+		v0 = vector_sign_sse2(v0);
+		v1 = vector_sign_sse2(v1);
+		v2 = vector_sign_sse2(v2);
+		v3 = vector_sign_sse2(v3);
+		v4 = vector_sign_sse2(v4);
+		v5 = vector_sign_sse2(v5);
+		v6 = vector_sign_sse2(v6);
+		v7 = vector_sign_sse2(v7);
+	}
+
+	benchmark::DoNotOptimize(v0);
+	benchmark::DoNotOptimize(v1);
+	benchmark::DoNotOptimize(v2);
+	benchmark::DoNotOptimize(v3);
+	benchmark::DoNotOptimize(v4);
+	benchmark::DoNotOptimize(v5);
+	benchmark::DoNotOptimize(v6);
+	benchmark::DoNotOptimize(v7);
 }
 
 BENCHMARK(bm_vector_sign_sse2);

--- a/tools/bench/sources/bench_vector_sign.cpp
+++ b/tools/bench/sources/bench_vector_sign.cpp
@@ -28,6 +28,8 @@
 
 using namespace rtm;
 
+// Wins on Ryzen 2990X desktop VS2017 x64 AVX
+// Despite taking 5 instructions unlike sse2 which needs 2, this is consistently faster as well.
 RTM_FORCE_NOINLINE vector4f RTM_SIMD_CALL vector_sign_ref(vector4f_arg0 input) RTM_NO_EXCEPT
 {
 	const mask4i mask = vector_greater_equal(input, vector_zero());
@@ -35,6 +37,7 @@ RTM_FORCE_NOINLINE vector4f RTM_SIMD_CALL vector_sign_ref(vector4f_arg0 input) R
 }
 
 #if defined(RTM_SSE2_INTRINSICS)
+// Wins on Haswell laptop x64 AVX
 RTM_FORCE_NOINLINE vector4f RTM_SIMD_CALL vector_sign_sse2(vector4f_arg0 input) RTM_NO_EXCEPT
 {
 	constexpr __m128 signs = { -0.0f, -0.0f, -0.0f, -0.0f };

--- a/tools/bench/sources/bench_vector_sign.cpp
+++ b/tools/bench/sources/bench_vector_sign.cpp
@@ -38,6 +38,7 @@ RTM_FORCE_NOINLINE vector4f RTM_SIMD_CALL vector_sign_ref(vector4f_arg0 input) R
 
 #if defined(RTM_SSE2_INTRINSICS)
 // Wins on Haswell laptop x64 AVX
+// Same performance as ref.
 // Wins on Ryzen 2990X desktop clang9 x64 AVX
 RTM_FORCE_NOINLINE vector4f RTM_SIMD_CALL vector_sign_sse2(vector4f_arg0 input) RTM_NO_EXCEPT
 {


### PR DESCRIPTION
Benchmark numbers were slightly inaccurate at times due to store forwarding penalties. Due to the nature of micro benchmarks, some functions may or may not be as fast as measured. They only serve to give a general idea.

At a later date, RTM will be benchmarked within ACL to get accurate measurements under a real application. Optimal implementations will be selected and added to RTM.