### PR TITLE
fix: lerp should be stable and return start/end exactly when alpha is 0.0/1.0

### DIFF
--- a/includes/rtm/scalard.h
+++ b/includes/rtm/scalard.h
@@ -312,7 +312,7 @@ namespace rtm
 	}
 
 	//////////////////////////////////////////////////////////////////////////
-	// Returns true if both inputs are nearly equal, false otherwise.
+	// Returns true if both inputs are nearly equal, otherwise false: abs(lhs - rhs) <= threshold
 	//////////////////////////////////////////////////////////////////////////
 	inline bool scalar_near_equal(double lhs, double rhs, double threshold) RTM_NO_EXCEPT
 	{
@@ -320,7 +320,7 @@ namespace rtm
 	}
 
 	//////////////////////////////////////////////////////////////////////////
-	// Returns true if both inputs are nearly equal, false otherwise.
+	// Returns true if both inputs are nearly equal, otherwise false: abs(lhs - rhs) <= 0.00001
 	//////////////////////////////////////////////////////////////////////////
 	RTM_DEPRECATED("Always specify a threshold explicitly, to be removed in v2.0")
 	inline bool scalar_near_equal(double lhs, double rhs) RTM_NO_EXCEPT
@@ -538,7 +538,7 @@ namespace rtm
 	}
 
 	//////////////////////////////////////////////////////////////////////////
-	// Returns true if both inputs are nearly equal, false otherwise.
+	// Returns true if both inputs are nearly equal, otherwise false: abs(lhs - rhs) <= threshold
 	//////////////////////////////////////////////////////////////////////////
 	inline bool scalar_near_equal(scalard lhs, scalard rhs, scalard threshold) RTM_NO_EXCEPT
 	{
@@ -546,7 +546,7 @@ namespace rtm
 	}
 
 	//////////////////////////////////////////////////////////////////////////
-	// Returns true if both inputs are nearly equal, false otherwise.
+	// Returns true if both inputs are nearly equal, otherwise false: abs(lhs - rhs) <= 0.00001
 	//////////////////////////////////////////////////////////////////////////
 	RTM_DEPRECATED("Always specify a threshold explicitly, to be removed in v2.0")
 	inline bool scalar_near_equal(scalard lhs, scalard rhs) RTM_NO_EXCEPT

--- a/includes/rtm/scalard.h
+++ b/includes/rtm/scalard.h
@@ -302,7 +302,7 @@ namespace rtm
 	//////////////////////////////////////////////////////////////////////////
 	inline bool scalar_near_equal(double lhs, double rhs, double threshold) RTM_NO_EXCEPT
 	{
-		return scalar_abs(lhs - rhs) < threshold;
+		return scalar_abs(lhs - rhs) <= threshold;
 	}
 
 	//////////////////////////////////////////////////////////////////////////
@@ -311,7 +311,7 @@ namespace rtm
 	RTM_DEPRECATED("Always specify a threshold explicitly, to be removed in v2.0")
 	inline bool scalar_near_equal(double lhs, double rhs) RTM_NO_EXCEPT
 	{
-		return scalar_abs(lhs - rhs) < 0.00001;
+		return scalar_abs(lhs - rhs) <= 0.00001;
 	}
 
 	//////////////////////////////////////////////////////////////////////////
@@ -499,7 +499,7 @@ namespace rtm
 	//////////////////////////////////////////////////////////////////////////
 	inline bool scalar_near_equal(scalard lhs, scalard rhs, scalard threshold) RTM_NO_EXCEPT
 	{
-		return scalar_is_lower(scalar_abs(scalar_sub(lhs, rhs)), threshold);
+		return scalar_is_lower_equal(scalar_abs(scalar_sub(lhs, rhs)), threshold);
 	}
 
 	//////////////////////////////////////////////////////////////////////////
@@ -508,7 +508,7 @@ namespace rtm
 	RTM_DEPRECATED("Always specify a threshold explicitly, to be removed in v2.0")
 	inline bool scalar_near_equal(scalard lhs, scalard rhs) RTM_NO_EXCEPT
 	{
-		return scalar_is_lower(scalar_abs(scalar_sub(lhs, rhs)), scalar_set(0.00001));
+		return scalar_is_lower_equal(scalar_abs(scalar_sub(lhs, rhs)), scalar_set(0.00001));
 	}
 #endif
 }

--- a/includes/rtm/scalard.h
+++ b/includes/rtm/scalard.h
@@ -184,6 +184,15 @@ namespace rtm
 	}
 
 	//////////////////////////////////////////////////////////////////////////
+	// Returns the negative multiplication/subtraction of the three inputs: -((s0 * s1) - s2)
+	// This is mathematically equivalent to: s2 - (s0 * s1)
+	//////////////////////////////////////////////////////////////////////////
+	constexpr double scalar_neg_mul_sub(double s0, double s1, double s2) RTM_NO_EXCEPT
+	{
+		return s2 - (s0 * s1);
+	}
+
+	//////////////////////////////////////////////////////////////////////////
 	// Returns the linear interpolation of the two inputs at the specified alpha.
 	//////////////////////////////////////////////////////////////////////////
 	constexpr double scalar_lerp(double start, double end, double alpha) RTM_NO_EXCEPT
@@ -412,6 +421,15 @@ namespace rtm
 	inline scalard RTM_SIMD_CALL scalar_mul_add(scalard s0, scalard s1, scalard s2) RTM_NO_EXCEPT
 	{
 		return _mm_add_sd(_mm_mul_sd(s0, s1), s2);
+	}
+
+	//////////////////////////////////////////////////////////////////////////
+	// Returns the negative multiplication/subtraction of the three inputs: -((s0 * s1) - s2)
+	// This is mathematically equivalent to: s2 - (s0 * s1)
+	//////////////////////////////////////////////////////////////////////////
+	inline scalard RTM_SIMD_CALL scalar_neg_mul_sub(scalard s0, scalard s1, scalard s2) RTM_NO_EXCEPT
+	{
+		return _mm_sub_sd(s2, _mm_mul_sd(s0, s1));
 	}
 
 	//////////////////////////////////////////////////////////////////////////

--- a/includes/rtm/scalarf.h
+++ b/includes/rtm/scalarf.h
@@ -240,6 +240,15 @@ namespace rtm
 	}
 
 	//////////////////////////////////////////////////////////////////////////
+	// Returns the negative multiplication/subtraction of the three inputs: -((s0 * s1) - s2)
+	// This is mathematically equivalent to: s2 - (s0 * s1)
+	//////////////////////////////////////////////////////////////////////////
+	constexpr float scalar_neg_mul_sub(float s0, float s1, float s2) RTM_NO_EXCEPT
+	{
+		return s2 - (s0 * s1);
+	}
+
+	//////////////////////////////////////////////////////////////////////////
 	// Returns the linear interpolation of the two inputs at the specified alpha.
 	//////////////////////////////////////////////////////////////////////////
 	constexpr float scalar_lerp(float start, float end, float alpha) RTM_NO_EXCEPT
@@ -477,6 +486,15 @@ namespace rtm
 	inline scalarf RTM_SIMD_CALL scalar_mul_add(scalarf_arg0 s0, scalarf_arg1 s1, scalarf_arg2 s2) RTM_NO_EXCEPT
 	{
 		return _mm_add_ss(_mm_mul_ss(s0, s1), s2);
+	}
+
+	//////////////////////////////////////////////////////////////////////////
+	// Returns the negative multiplication/subtraction of the three inputs: -((s0 * s1) - s2)
+	// This is mathematically equivalent to: s2 - (s0 * s1)
+	//////////////////////////////////////////////////////////////////////////
+	inline scalarf RTM_SIMD_CALL scalar_neg_mul_sub(scalarf_arg0 s0, scalarf_arg1 s1, scalarf_arg2 s2) RTM_NO_EXCEPT
+	{
+		return _mm_sub_ss(s2, _mm_mul_ss(s0, s1));
 	}
 
 	//////////////////////////////////////////////////////////////////////////

--- a/includes/rtm/scalarf.h
+++ b/includes/rtm/scalarf.h
@@ -358,7 +358,7 @@ namespace rtm
 	//////////////////////////////////////////////////////////////////////////
 	inline bool scalar_near_equal(float lhs, float rhs, float threshold) RTM_NO_EXCEPT
 	{
-		return scalar_abs(lhs - rhs) < threshold;
+		return scalar_abs(lhs - rhs) <= threshold;
 	}
 
 	//////////////////////////////////////////////////////////////////////////
@@ -367,7 +367,7 @@ namespace rtm
 	RTM_DEPRECATED("Always specify a threshold explicitly, to be removed in v2.0")
 	inline bool scalar_near_equal(float lhs, float rhs) RTM_NO_EXCEPT
 	{
-		return scalar_abs(lhs - rhs) < 0.00001F;
+		return scalar_abs(lhs - rhs) <= 0.00001F;
 	}
 
 	//////////////////////////////////////////////////////////////////////////
@@ -569,7 +569,7 @@ namespace rtm
 	//////////////////////////////////////////////////////////////////////////
 	inline bool scalar_near_equal(scalarf_arg0 lhs, scalarf_arg1 rhs, scalarf_arg2 threshold) RTM_NO_EXCEPT
 	{
-		return scalar_is_lower(scalar_abs(scalar_sub(lhs, rhs)), threshold);
+		return scalar_is_lower_equal(scalar_abs(scalar_sub(lhs, rhs)), threshold);
 	}
 
 	//////////////////////////////////////////////////////////////////////////
@@ -578,7 +578,7 @@ namespace rtm
 	RTM_DEPRECATED("Always specify a threshold explicitly, to be removed in v2.0")
 	inline bool scalar_near_equal(scalarf_arg0 lhs, scalarf_arg1 rhs) RTM_NO_EXCEPT
 	{
-		return scalar_is_lower(scalar_abs(scalar_sub(lhs, rhs)), scalar_set(0.00001F));
+		return scalar_is_lower_equal(scalar_abs(scalar_sub(lhs, rhs)), scalar_set(0.00001F));
 	}
 #endif
 }

--- a/includes/rtm/scalarf.h
+++ b/includes/rtm/scalarf.h
@@ -368,7 +368,7 @@ namespace rtm
 	}
 
 	//////////////////////////////////////////////////////////////////////////
-	// Returns true if both inputs are nearly equal, false otherwise.
+	// Returns true if both inputs are nearly equal, otherwise false: abs(lhs - rhs) <= threshold
 	//////////////////////////////////////////////////////////////////////////
 	inline bool scalar_near_equal(float lhs, float rhs, float threshold) RTM_NO_EXCEPT
 	{
@@ -376,7 +376,7 @@ namespace rtm
 	}
 
 	//////////////////////////////////////////////////////////////////////////
-	// Returns true if both inputs are nearly equal, false otherwise.
+	// Returns true if both inputs are nearly equal, otherwise false: abs(lhs - rhs) <= 0.00001
 	//////////////////////////////////////////////////////////////////////////
 	RTM_DEPRECATED("Always specify a threshold explicitly, to be removed in v2.0")
 	inline bool scalar_near_equal(float lhs, float rhs) RTM_NO_EXCEPT
@@ -608,7 +608,7 @@ namespace rtm
 	}
 
 	//////////////////////////////////////////////////////////////////////////
-	// Returns true if both inputs are nearly equal, false otherwise.
+	// Returns true if both inputs are nearly equal, otherwise false: abs(lhs - rhs) <= threshold
 	//////////////////////////////////////////////////////////////////////////
 	inline bool scalar_near_equal(scalarf_arg0 lhs, scalarf_arg1 rhs, scalarf_arg2 threshold) RTM_NO_EXCEPT
 	{
@@ -616,7 +616,7 @@ namespace rtm
 	}
 
 	//////////////////////////////////////////////////////////////////////////
-	// Returns true if both inputs are nearly equal, false otherwise.
+	// Returns true if both inputs are nearly equal, otherwise false: abs(lhs - rhs) <= 0.00001
 	//////////////////////////////////////////////////////////////////////////
 	RTM_DEPRECATED("Always specify a threshold explicitly, to be removed in v2.0")
 	inline bool scalar_near_equal(scalarf_arg0 lhs, scalarf_arg1 rhs) RTM_NO_EXCEPT

--- a/includes/rtm/vector4d.h
+++ b/includes/rtm/vector4d.h
@@ -1051,7 +1051,7 @@ namespace rtm
 	}
 
 	//////////////////////////////////////////////////////////////////////////
-	// Returns true if all 4 components are near equal, otherwise false: all(abs(lhs - rhs) < threshold)
+	// Returns true if all 4 components are near equal, otherwise false: all(abs(lhs - rhs) <= threshold)
 	//////////////////////////////////////////////////////////////////////////
 	inline bool vector_all_near_equal(const vector4d& lhs, const vector4d& rhs, double threshold = 0.00001) RTM_NO_EXCEPT
 	{
@@ -1059,7 +1059,7 @@ namespace rtm
 	}
 
 	//////////////////////////////////////////////////////////////////////////
-	// Returns true if all 2 components are near equal, otherwise false: all(abs(lhs - rhs) < threshold)
+	// Returns true if all 2 components are near equal, otherwise false: all(abs(lhs - rhs) <= threshold)
 	//////////////////////////////////////////////////////////////////////////
 	inline bool vector_all_near_equal2(const vector4d& lhs, const vector4d& rhs, double threshold = 0.00001) RTM_NO_EXCEPT
 	{
@@ -1067,7 +1067,7 @@ namespace rtm
 	}
 
 	//////////////////////////////////////////////////////////////////////////
-	// Returns true if all 3 components are near equal, otherwise false: all(abs(lhs - rhs) < threshold)
+	// Returns true if all 3 components are near equal, otherwise false: all(abs(lhs - rhs) <= threshold)
 	//////////////////////////////////////////////////////////////////////////
 	inline bool vector_all_near_equal3(const vector4d& lhs, const vector4d& rhs, double threshold = 0.00001) RTM_NO_EXCEPT
 	{
@@ -1075,7 +1075,7 @@ namespace rtm
 	}
 
 	//////////////////////////////////////////////////////////////////////////
-	// Returns true if any 4 components are near equal, otherwise false: any(abs(lhs - rhs) < threshold)
+	// Returns true if any 4 components are near equal, otherwise false: any(abs(lhs - rhs) <= threshold)
 	//////////////////////////////////////////////////////////////////////////
 	inline bool vector_any_near_equal(const vector4d& lhs, const vector4d& rhs, double threshold = 0.00001) RTM_NO_EXCEPT
 	{
@@ -1083,7 +1083,7 @@ namespace rtm
 	}
 
 	//////////////////////////////////////////////////////////////////////////
-	// Returns true if any 2 components are near equal, otherwise false: any(abs(lhs - rhs) < threshold)
+	// Returns true if any 2 components are near equal, otherwise false: any(abs(lhs - rhs) <= threshold)
 	//////////////////////////////////////////////////////////////////////////
 	inline bool vector_any_near_equal2(const vector4d& lhs, const vector4d& rhs, double threshold = 0.00001) RTM_NO_EXCEPT
 	{
@@ -1091,7 +1091,7 @@ namespace rtm
 	}
 
 	//////////////////////////////////////////////////////////////////////////
-	// Returns true if any 3 components are near equal, otherwise false: any(abs(lhs - rhs) < threshold)
+	// Returns true if any 3 components are near equal, otherwise false: any(abs(lhs - rhs) <= threshold)
 	//////////////////////////////////////////////////////////////////////////
 	inline bool vector_any_near_equal3(const vector4d& lhs, const vector4d& rhs, double threshold = 0.00001) RTM_NO_EXCEPT
 	{

--- a/includes/rtm/vector4d.h
+++ b/includes/rtm/vector4d.h
@@ -744,10 +744,15 @@ namespace rtm
 
 	//////////////////////////////////////////////////////////////////////////
 	// Per component linear interpolation of the two inputs at the specified alpha.
+	// The formula used is: ((1.0 - alpha) * start) + (alpha * end).
+	// Interpolation is stable and will return 'start' when alpha is 0.0 and 'end' when it is 1.0.
+	// This is the same instruction count when FMA is present but it might be slightly slower
+	// due to the extra multiplication compared to: start + (alpha * (end - start)).
 	//////////////////////////////////////////////////////////////////////////
 	inline vector4d vector_lerp(const vector4d& start, const vector4d& end, double alpha) RTM_NO_EXCEPT
 	{
-		return vector_mul_add(vector_sub(end, start), alpha, start);
+		// ((1.0 - alpha) * start) + (alpha * end) == (start - alpha * start) + (alpha * end)
+		return vector_mul_add(end, alpha, vector_neg_mul_sub(start, alpha, start));
 	}
 
 

--- a/includes/rtm/vector4f.h
+++ b/includes/rtm/vector4f.h
@@ -1313,7 +1313,7 @@ namespace rtm
 	}
 
 	//////////////////////////////////////////////////////////////////////////
-	// Returns true if all 4 components are near equal, otherwise false: all(abs(lhs - rhs) < threshold)
+	// Returns true if all 4 components are near equal, otherwise false: all(abs(lhs - rhs) <= threshold)
 	//////////////////////////////////////////////////////////////////////////
 	inline bool RTM_SIMD_CALL vector_all_near_equal(vector4f_arg0 lhs, vector4f_arg1 rhs, float threshold = 0.00001F) RTM_NO_EXCEPT
 	{
@@ -1321,7 +1321,7 @@ namespace rtm
 	}
 
 	//////////////////////////////////////////////////////////////////////////
-	// Returns true if all 2 components are near equal, otherwise false: all(abs(lhs - rhs) < threshold)
+	// Returns true if all 2 components are near equal, otherwise false: all(abs(lhs - rhs) <= threshold)
 	//////////////////////////////////////////////////////////////////////////
 	inline bool RTM_SIMD_CALL vector_all_near_equal2(vector4f_arg0 lhs, vector4f_arg1 rhs, float threshold = 0.00001F) RTM_NO_EXCEPT
 	{
@@ -1329,7 +1329,7 @@ namespace rtm
 	}
 
 	//////////////////////////////////////////////////////////////////////////
-	// Returns true if all 3 components are near equal, otherwise false: all(abs(lhs - rhs) < threshold)
+	// Returns true if all 3 components are near equal, otherwise false: all(abs(lhs - rhs) <= threshold)
 	//////////////////////////////////////////////////////////////////////////
 	inline bool RTM_SIMD_CALL vector_all_near_equal3(vector4f_arg0 lhs, vector4f_arg1 rhs, float threshold = 0.00001F) RTM_NO_EXCEPT
 	{
@@ -1337,7 +1337,7 @@ namespace rtm
 	}
 
 	//////////////////////////////////////////////////////////////////////////
-	// Returns true if any 4 components are near equal, otherwise false: any(abs(lhs - rhs) < threshold)
+	// Returns true if any 4 components are near equal, otherwise false: any(abs(lhs - rhs) <= threshold)
 	//////////////////////////////////////////////////////////////////////////
 	inline bool RTM_SIMD_CALL vector_any_near_equal(vector4f_arg0 lhs, vector4f_arg1 rhs, float threshold = 0.00001F) RTM_NO_EXCEPT
 	{
@@ -1345,7 +1345,7 @@ namespace rtm
 	}
 
 	//////////////////////////////////////////////////////////////////////////
-	// Returns true if any 2 components are near equal, otherwise false: any(abs(lhs - rhs) < threshold)
+	// Returns true if any 2 components are near equal, otherwise false: any(abs(lhs - rhs) <= threshold)
 	//////////////////////////////////////////////////////////////////////////
 	inline bool RTM_SIMD_CALL vector_any_near_equal2(vector4f_arg0 lhs, vector4f_arg1 rhs, float threshold = 0.00001F) RTM_NO_EXCEPT
 	{
@@ -1353,7 +1353,7 @@ namespace rtm
 	}
 
 	//////////////////////////////////////////////////////////////////////////
-	// Returns true if any 3 components are near equal, otherwise false: any(abs(lhs - rhs) < threshold)
+	// Returns true if any 3 components are near equal, otherwise false: any(abs(lhs - rhs) <= threshold)
 	//////////////////////////////////////////////////////////////////////////
 	inline bool RTM_SIMD_CALL vector_any_near_equal3(vector4f_arg0 lhs, vector4f_arg1 rhs, float threshold = 0.00001F) RTM_NO_EXCEPT
 	{

--- a/includes/rtm/vector4f.h
+++ b/includes/rtm/vector4f.h
@@ -958,10 +958,15 @@ namespace rtm
 
 	//////////////////////////////////////////////////////////////////////////
 	// Per component linear interpolation of the two inputs at the specified alpha.
+	// The formula used is: ((1.0 - alpha) * start) + (alpha * end).
+	// Interpolation is stable and will return 'start' when alpha is 0.0 and 'end' when it is 1.0.
+	// This is the same instruction count when FMA is present but it might be slightly slower
+	// due to the extra multiplication compared to: start + (alpha * (end - start)).
 	//////////////////////////////////////////////////////////////////////////
 	inline vector4f RTM_SIMD_CALL vector_lerp(vector4f_arg0 start, vector4f_arg1 end, float alpha) RTM_NO_EXCEPT
 	{
-		return vector_mul_add(vector_sub(end, start), alpha, start);
+		// ((1.0 - alpha) * start) + (alpha * end) == (start - alpha * start) + (alpha * end)
+		return vector_mul_add(end, alpha, vector_neg_mul_sub(start, alpha, start));
 	}
 
 

--- a/tests/sources/test_quat.cpp
+++ b/tests/sources/test_quat.cpp
@@ -272,8 +272,8 @@ static void test_quat_impl(const FloatType threshold)
 	}
 
 	{
-		QuatType quat0 = quat_from_euler(degrees(FloatType(30.0)), degrees(FloatType(-45.0)), degrees(FloatType(90.0)));
-		QuatType quat1 = quat_from_euler(degrees(FloatType(45.0)), degrees(FloatType(60.0)), degrees(FloatType(120.0)));
+		QuatType quat0 = quat_normalize(quat_from_euler(degrees(FloatType(30.0)), degrees(FloatType(-45.0)), degrees(FloatType(90.0))));
+		QuatType quat1 = quat_normalize(quat_from_euler(degrees(FloatType(45.0)), degrees(FloatType(60.0)), degrees(FloatType(120.0))));
 
 		QuatType scalar_result = scalar_lerp<QuatType, FloatType>(quat0, quat1, FloatType(0.33));
 
@@ -287,6 +287,11 @@ static void test_quat_impl(const FloatType threshold)
 		CHECK(scalar_near_equal(quat_get_y(quat_lerp(quat0, quat1, FloatType(0.33))), quat_get_y(scalar_result), threshold));
 		CHECK(scalar_near_equal(quat_get_z(quat_lerp(quat0, quat1, FloatType(0.33))), quat_get_z(scalar_result), threshold));
 		CHECK(scalar_near_equal(quat_get_w(quat_lerp(quat0, quat1, FloatType(0.33))), quat_get_w(scalar_result), threshold));
+
+		// Lerp must be stable and return exactly the start when the interpolation alpha is 0.0 and exactly the end when 1.0
+		// When alpha is 0.0, start is always exactly returned but when it is 1.0, the end might be the negated equivalent
+		CHECK(vector_all_near_equal(quat_to_vector(quat_lerp(quat0, quat1, FloatType(0.0))), quat_to_vector(quat0), FloatType(0.0)));
+		CHECK(vector_all_near_equal(quat_to_vector(quat_lerp(quat0, quat1, FloatType(1.0))), quat_to_vector(quat_neg(quat1)), FloatType(0.0)));
 	}
 
 	{

--- a/tests/sources/test_scalar.cpp
+++ b/tests/sources/test_scalar.cpp
@@ -167,7 +167,7 @@ static void test_scalar_impl(const FloatType threshold)
 	CHECK(scalar_near_equal(scalar_cast(scalar_div(scalar_set(FloatType(1.0)), scalar_set(FloatType(-0.5)))), FloatType(1.0) / FloatType(-0.5), threshold));
 	CHECK(scalar_near_equal(scalar_cast(scalar_div(scalar_set(FloatType(1.0)), scalar_set(FloatType(1.0)))), FloatType(1.0) / FloatType(1.0), threshold));
 
-	const FloatType values[] = { FloatType(-0.5123), FloatType(1.0341), FloatType(-0.54132) };
+	const FloatType values[] = { FloatType(-1.0 / 3.0), FloatType(0.0341), FloatType(-0.54132) };
 	CHECK(scalar_near_equal(scalar_mul_add(values[0], values[1], values[2]), (values[0] * values[1]) + values[2], threshold));
 	CHECK(scalar_near_equal(scalar_cast(scalar_mul_add(scalar_set(values[0]), scalar_set(values[1]), scalar_set(values[2]))), (values[0] * values[1]) + values[2], threshold));
 
@@ -175,7 +175,13 @@ static void test_scalar_impl(const FloatType threshold)
 	CHECK(scalar_near_equal(scalar_cast(scalar_neg_mul_sub(scalar_set(values[0]), scalar_set(values[1]), scalar_set(values[2]))), values[2] - (values[0] * values[1]), threshold));
 
 	CHECK(scalar_near_equal(scalar_lerp(values[0], values[1], values[2]), ((values[1] - values[0]) * values[2]) + values[0], threshold));
-	CHECK(scalar_near_equal(scalar_cast(scalar_lerp(scalar_set(values[0]), scalar_set(values[1]), values[2])), ((values[1] - values[0]) * values[2]) + values[0], threshold));
+	CHECK(scalar_near_equal(scalar_lerp(scalar_set(values[0]), scalar_set(values[1]), scalar_set(values[2])), scalar_set(((values[1] - values[0]) * values[2]) + values[0]), scalar_set(threshold)));
+
+	// Lerp must be stable and return exactly the start when the interpolation alpha is 0.0 and exactly the end when 1.0
+	CHECK(scalar_near_equal(scalar_lerp(values[0], values[1], FloatType(0.0)), values[0], FloatType(0.0)));
+	CHECK(scalar_near_equal(scalar_lerp(values[0], values[1], FloatType(1.0)), values[1], FloatType(0.0)));
+	CHECK(scalar_near_equal(scalar_lerp(scalar_set(values[0]), scalar_set(values[1]), scalar_set(FloatType(0.0))), scalar_set(values[0]), scalar_set(FloatType(0.0))));
+	CHECK(scalar_near_equal(scalar_lerp(scalar_set(values[0]), scalar_set(values[1]), scalar_set(FloatType(1.0))), scalar_set(values[1]), scalar_set(FloatType(0.0))));
 
 	using AngleType = typename float_traits<FloatType>::angle;
 

--- a/tests/sources/test_scalar.cpp
+++ b/tests/sources/test_scalar.cpp
@@ -171,6 +171,9 @@ static void test_scalar_impl(const FloatType threshold)
 	CHECK(scalar_near_equal(scalar_mul_add(values[0], values[1], values[2]), (values[0] * values[1]) + values[2], threshold));
 	CHECK(scalar_near_equal(scalar_cast(scalar_mul_add(scalar_set(values[0]), scalar_set(values[1]), scalar_set(values[2]))), (values[0] * values[1]) + values[2], threshold));
 
+	CHECK(scalar_near_equal(scalar_neg_mul_sub(values[0], values[1], values[2]), values[2] - (values[0] * values[1]), threshold));
+	CHECK(scalar_near_equal(scalar_cast(scalar_neg_mul_sub(scalar_set(values[0]), scalar_set(values[1]), scalar_set(values[2]))), values[2] - (values[0] * values[1]), threshold));
+
 	CHECK(scalar_near_equal(scalar_lerp(values[0], values[1], values[2]), ((values[1] - values[0]) * values[2]) + values[0], threshold));
 	CHECK(scalar_near_equal(scalar_cast(scalar_lerp(scalar_set(values[0]), scalar_set(values[1]), values[2])), ((values[1] - values[0]) * values[2]) + values[0], threshold));
 

--- a/tests/sources/test_vector4_impl.h
+++ b/tests/sources/test_vector4_impl.h
@@ -444,6 +444,10 @@ void test_vector4_arithmetic_impl(const FloatType threshold)
 	CHECK(scalar_near_equal(vector_get_z(vector_lerp(test_value10, test_value11, FloatType(0.33))), ((test_value11_flt[2] - test_value10_flt[2]) * FloatType(0.33)) + test_value10_flt[2], threshold));
 	CHECK(scalar_near_equal(vector_get_w(vector_lerp(test_value10, test_value11, FloatType(0.33))), ((test_value11_flt[3] - test_value10_flt[3]) * FloatType(0.33)) + test_value10_flt[3], threshold));
 
+	// Lerp must be stable and return exactly the start when the interpolation alpha is 0.0 and exactly the end when 1.0
+	CHECK(vector_all_near_equal(vector_lerp(test_value10, test_value11, FloatType(0.0)), test_value10, FloatType(0.0)));
+	CHECK(vector_all_near_equal(vector_lerp(test_value10, test_value11, FloatType(1.0)), test_value11, FloatType(0.0)));
+
 	CHECK(scalar_near_equal(vector_get_x(vector_fraction(test_value0)), scalar_fraction(test_value0_flt[0]), threshold));
 	CHECK(scalar_near_equal(vector_get_y(vector_fraction(test_value0)), scalar_fraction(test_value0_flt[1]), threshold));
 	CHECK(scalar_near_equal(vector_get_z(vector_fraction(test_value0)), scalar_fraction(test_value0_flt[2]), threshold));


### PR DESCRIPTION
See [here](https://fgiesen.wordpress.com/2012/08/15/linear-interpolation-past-present-and-future/) as well for details. Tested with [ACL](https://github.com/nfrechette/acl/issues/51) and everything is working as intended.

Having a stable lerp by default is more important than the 1-3 cycles saved to avoid a multiplication that can often be fused. If there is a need, it can either be implemented by hand by the user trivially or we can add `vector_lerp_fast` and related variants.