### PR TITLE
fix: partial vector loads zero unused lanes

### DIFF
--- a/includes/rtm/impl/scalar_common.h
+++ b/includes/rtm/impl/scalar_common.h
@@ -49,7 +49,7 @@ namespace rtm
 #if defined(RTM_SSE2_INTRINSICS)
 			inline RTM_SIMD_CALL operator scalarf() const RTM_NO_EXCEPT
 			{
-				return _mm_load1_ps(ptr);
+				return _mm_load_ss(ptr);
 			}
 #endif
 
@@ -72,7 +72,7 @@ namespace rtm
 #if defined(RTM_SSE2_INTRINSICS)
 			inline RTM_SIMD_CALL operator scalard() const RTM_NO_EXCEPT
 			{
-				return _mm_load1_pd(ptr);
+				return _mm_load_sd(ptr);
 			}
 #endif
 

--- a/includes/rtm/impl/vector_common.h
+++ b/includes/rtm/impl/vector_common.h
@@ -256,7 +256,7 @@ namespace rtm
 				{
 					double data[1];
 					std::memcpy(&data[0], ptr, sizeof(double) * 1);
-					return vector_set(data[0]);
+					return vector_set(data[0], 0.0, 0.0, 0.0);
 				}
 				case vector_unaligned_loader_width::vec2:
 				{
@@ -288,7 +288,7 @@ namespace rtm
 				{
 					float data[1];
 					std::memcpy(&data[0], ptr, sizeof(float) * 1);
-					return vector_set(data[0]);
+					return vector_set(data[0], 0.0F, 0.0F, 0.0F);
 				}
 				case vector_unaligned_loader_width::vec2:
 				{
@@ -529,7 +529,7 @@ namespace rtm
 	}
 
 	//////////////////////////////////////////////////////////////////////////
-	// Loads an unaligned vector1 from memory and leaves the [yzw] components undefined.
+	// Loads an unaligned vector1 from memory and sets the [yzw] components to zero.
 	//////////////////////////////////////////////////////////////////////////
 	constexpr rtm_impl::vector_unaligned_loader<rtm_impl::vector_unaligned_loader_width::vec1> RTM_SIMD_CALL vector_load1(const uint8_t* input) RTM_NO_EXCEPT
 	{
@@ -537,7 +537,7 @@ namespace rtm
 	}
 
 	//////////////////////////////////////////////////////////////////////////
-	// Loads an unaligned vector2 from memory and leaves the [zw] components undefined.
+	// Loads an unaligned vector2 from memory and sets the [zw] components to zero.
 	//////////////////////////////////////////////////////////////////////////
 	constexpr rtm_impl::vector_unaligned_loader<rtm_impl::vector_unaligned_loader_width::vec2> RTM_SIMD_CALL vector_load2(const uint8_t* input) RTM_NO_EXCEPT
 	{
@@ -545,7 +545,7 @@ namespace rtm
 	}
 
 	//////////////////////////////////////////////////////////////////////////
-	// Loads an unaligned vector3 from memory and leaves the [w] component undefined.
+	// Loads an unaligned vector3 from memory and sets the [w] component to zero.
 	//////////////////////////////////////////////////////////////////////////
 	constexpr rtm_impl::vector_unaligned_loader<rtm_impl::vector_unaligned_loader_width::vec3> RTM_SIMD_CALL vector_load3(const uint8_t* input) RTM_NO_EXCEPT
 	{

--- a/includes/rtm/vector4d.h
+++ b/includes/rtm/vector4d.h
@@ -49,15 +49,15 @@ namespace rtm
 	}
 
 	//////////////////////////////////////////////////////////////////////////
-	// Loads an unaligned vector1 from memory and leaves the [yzw] components undefined.
+	// Loads an unaligned vector1 from memory and sets the [yzw] components to zero.
 	//////////////////////////////////////////////////////////////////////////
 	inline vector4d vector_load1(const double* input) RTM_NO_EXCEPT
 	{
-		return vector_set(input[0]);
+		return vector_set(input[0], 0.0, 0.0, 0.0);
 	}
 
 	//////////////////////////////////////////////////////////////////////////
-	// Loads an unaligned vector2 from memory and leaves the [zw] components undefined.
+	// Loads an unaligned vector2 from memory and sets the [zw] components to zero.
 	//////////////////////////////////////////////////////////////////////////
 	inline vector4d vector_load2(const double* input) RTM_NO_EXCEPT
 	{
@@ -65,7 +65,7 @@ namespace rtm
 	}
 
 	//////////////////////////////////////////////////////////////////////////
-	// Loads an unaligned vector3 from memory and leaves the [w] component undefined.
+	// Loads an unaligned vector3 from memory and sets the [w] component to zero.
 	//////////////////////////////////////////////////////////////////////////
 	inline vector4d vector_load3(const double* input) RTM_NO_EXCEPT
 	{
@@ -81,7 +81,7 @@ namespace rtm
 	}
 
 	//////////////////////////////////////////////////////////////////////////
-	// Loads an unaligned vector2 from memory and leaves the [zw] components undefined.
+	// Loads an unaligned vector2 from memory and sets the [zw] components to zero.
 	//////////////////////////////////////////////////////////////////////////
 	inline vector4d vector_load2(const float2d* input) RTM_NO_EXCEPT
 	{
@@ -89,7 +89,7 @@ namespace rtm
 	}
 
 	//////////////////////////////////////////////////////////////////////////
-	// Loads an unaligned vector3 from memory and leaves the [w] component undefined.
+	// Loads an unaligned vector3 from memory and sets the [w] component to zero.
 	//////////////////////////////////////////////////////////////////////////
 	inline vector4d vector_load3(const float3d* input) RTM_NO_EXCEPT
 	{

--- a/includes/rtm/vector4f.h
+++ b/includes/rtm/vector4f.h
@@ -55,21 +55,21 @@ namespace rtm
 	}
 
 	//////////////////////////////////////////////////////////////////////////
-	// Loads an unaligned vector1 from memory and leaves the [yzw] components undefined.
+	// Loads an unaligned vector1 from memory and sets the [yzw] components to zero.
 	//////////////////////////////////////////////////////////////////////////
 	inline vector4f RTM_SIMD_CALL vector_load1(const float* input) RTM_NO_EXCEPT
 	{
 #if defined(RTM_SSE2_INTRINSICS)
-		return _mm_load_ps1(input);
+		return _mm_load_ss(input);
 #elif defined(RTM_NEON_INTRINSICS)
-		return vld1q_dup_f32(input);
+		return vld1q_lane_f32(input, vdupq_n_f32(0.0F), 0);
 #else
-		return vector_set(input[0]);
+		return vector_set(input[0], 0.0F, 0.0F, 0.0F);
 #endif
 	}
 
 	//////////////////////////////////////////////////////////////////////////
-	// Loads an unaligned vector2 from memory and leaves the [zw] components undefined.
+	// Loads an unaligned vector2 from memory and sets the [zw] components to zero.
 	//////////////////////////////////////////////////////////////////////////
 	inline vector4f RTM_SIMD_CALL vector_load2(const float* input) RTM_NO_EXCEPT
 	{
@@ -77,7 +77,7 @@ namespace rtm
 	}
 
 	//////////////////////////////////////////////////////////////////////////
-	// Loads an unaligned vector3 from memory and leaves the [w] component undefined.
+	// Loads an unaligned vector3 from memory and sets the [w] component to zero.
 	//////////////////////////////////////////////////////////////////////////
 	inline vector4f RTM_SIMD_CALL vector_load3(const float* input) RTM_NO_EXCEPT
 	{
@@ -99,7 +99,7 @@ namespace rtm
 	}
 
 	//////////////////////////////////////////////////////////////////////////
-	// Loads an unaligned vector2 from memory and leaves the [zw] components undefined.
+	// Loads an unaligned vector2 from memory and sets the [zw] components to zero.
 	//////////////////////////////////////////////////////////////////////////
 	inline vector4f RTM_SIMD_CALL vector_load2(const float2f* input) RTM_NO_EXCEPT
 	{
@@ -107,7 +107,7 @@ namespace rtm
 	}
 
 	//////////////////////////////////////////////////////////////////////////
-	// Loads an unaligned vector3 from memory and leaves the [w] component undefined.
+	// Loads an unaligned vector3 from memory and sets the [w] component to zero.
 	//////////////////////////////////////////////////////////////////////////
 	inline vector4f RTM_SIMD_CALL vector_load3(const float3f* input) RTM_NO_EXCEPT
 	{

--- a/tests/sources/test_vector4_impl.h
+++ b/tests/sources/test_vector4_impl.h
@@ -152,14 +152,20 @@ void test_vector4_getset_impl()
 	CHECK(vector_get_z((Vector4Type)vector_load(&tmp.values[0])) == tmp.values[2]);
 	CHECK(vector_get_w((Vector4Type)vector_load(&tmp.values[0])) == tmp.values[3]);
 
-	CHECK(vector_get_x((Vector4Type)vector_load1(&tmp.values[0])) == tmp.values[0]);
+	CHECK(vector_get_x((Vector4Type)vector_load1(&tmp.values[1])) == tmp.values[1]);
+	CHECK(vector_get_y((Vector4Type)vector_load1(&tmp.values[1])) == FloatType(0.0));
+	CHECK(vector_get_z((Vector4Type)vector_load1(&tmp.values[1])) == FloatType(0.0));
+	CHECK(vector_get_w((Vector4Type)vector_load1(&tmp.values[1])) == FloatType(0.0));
 
-	CHECK(vector_get_x((Vector4Type)vector_load2(&tmp.values[0])) == tmp.values[0]);
-	CHECK(vector_get_y((Vector4Type)vector_load2(&tmp.values[0])) == tmp.values[1]);
+	CHECK(vector_get_x((Vector4Type)vector_load2(&tmp.values[1])) == tmp.values[1]);
+	CHECK(vector_get_y((Vector4Type)vector_load2(&tmp.values[1])) == tmp.values[2]);
+	CHECK(vector_get_z((Vector4Type)vector_load2(&tmp.values[1])) == FloatType(0.0));
+	CHECK(vector_get_w((Vector4Type)vector_load2(&tmp.values[1])) == FloatType(0.0));
 
-	CHECK(vector_get_x((Vector4Type)vector_load3(&tmp.values[0])) == tmp.values[0]);
-	CHECK(vector_get_y((Vector4Type)vector_load3(&tmp.values[0])) == tmp.values[1]);
-	CHECK(vector_get_z((Vector4Type)vector_load3(&tmp.values[0])) == tmp.values[2]);
+	CHECK(vector_get_x((Vector4Type)vector_load3(&tmp.values[1])) == tmp.values[1]);
+	CHECK(vector_get_y((Vector4Type)vector_load3(&tmp.values[1])) == tmp.values[2]);
+	CHECK(vector_get_z((Vector4Type)vector_load3(&tmp.values[1])) == tmp.values[3]);
+	CHECK(vector_get_w((Vector4Type)vector_load3(&tmp.values[1])) == FloatType(0.0));
 
 	Float2Type tmpf2 = { tmp.values[0], tmp.values[1] };
 	Float3Type tmpf3 = { tmp.values[0], tmp.values[1], tmp.values[2] };
@@ -167,10 +173,13 @@ void test_vector4_getset_impl()
 
 	CHECK(vector_get_x((Vector4Type)vector_load2(&tmpf2)) == tmpf2.x);
 	CHECK(vector_get_y((Vector4Type)vector_load2(&tmpf2)) == tmpf2.y);
+	CHECK(vector_get_z((Vector4Type)vector_load2(&tmpf2)) == FloatType(0.0));
+	CHECK(vector_get_w((Vector4Type)vector_load2(&tmpf2)) == FloatType(0.0));
 
 	CHECK(vector_get_x((Vector4Type)vector_load3(&tmpf3)) == tmpf3.x);
 	CHECK(vector_get_y((Vector4Type)vector_load3(&tmpf3)) == tmpf3.y);
 	CHECK(vector_get_z((Vector4Type)vector_load3(&tmpf3)) == tmpf3.z);
+	CHECK(vector_get_w((Vector4Type)vector_load3(&tmpf3)) == FloatType(0.0));
 
 	CHECK(vector_get_x((Vector4Type)vector_load(&tmpf4)) == tmpf4.x);
 	CHECK(vector_get_y((Vector4Type)vector_load(&tmpf4)) == tmpf4.y);
@@ -183,17 +192,20 @@ void test_vector4_getset_impl()
 	CHECK(vector_get_z((Vector4Type)vector_load(&buffer[1])) == tmp.values[2]);
 	CHECK(vector_get_w((Vector4Type)vector_load(&buffer[1])) == tmp.values[3]);
 
-	CHECK(vector_get_x((Vector4Type)vector_load1(&buffer[1])) == tmp.values[0]);
-	CHECK(vector_get_y((Vector4Type)vector_load1(&buffer[1])) == tmp.values[0]);
-	CHECK(vector_get_z((Vector4Type)vector_load1(&buffer[1])) == tmp.values[0]);
-	CHECK(vector_get_w((Vector4Type)vector_load1(&buffer[1])) == tmp.values[0]);
+	CHECK(vector_get_x((Vector4Type)vector_load1(&buffer[1 + sizeof(FloatType)])) == tmp.values[1]);
+	CHECK(vector_get_y((Vector4Type)vector_load1(&buffer[1 + sizeof(FloatType)])) == FloatType(0.0));
+	CHECK(vector_get_z((Vector4Type)vector_load1(&buffer[1 + sizeof(FloatType)])) == FloatType(0.0));
+	CHECK(vector_get_w((Vector4Type)vector_load1(&buffer[1 + sizeof(FloatType)])) == FloatType(0.0));
 
-	CHECK(vector_get_x((Vector4Type)vector_load2(&buffer[1])) == tmp.values[0]);
-	CHECK(vector_get_y((Vector4Type)vector_load2(&buffer[1])) == tmp.values[1]);
+	CHECK(vector_get_x((Vector4Type)vector_load2(&buffer[1 + sizeof(FloatType)])) == tmp.values[1]);
+	CHECK(vector_get_y((Vector4Type)vector_load2(&buffer[1 + sizeof(FloatType)])) == tmp.values[2]);
+	CHECK(vector_get_z((Vector4Type)vector_load2(&buffer[1 + sizeof(FloatType)])) == FloatType(0.0));
+	CHECK(vector_get_w((Vector4Type)vector_load2(&buffer[1 + sizeof(FloatType)])) == FloatType(0.0));
 
-	CHECK(vector_get_x((Vector4Type)vector_load3(&buffer[1])) == tmp.values[0]);
-	CHECK(vector_get_y((Vector4Type)vector_load3(&buffer[1])) == tmp.values[1]);
-	CHECK(vector_get_z((Vector4Type)vector_load3(&buffer[1])) == tmp.values[2]);
+	CHECK(vector_get_x((Vector4Type)vector_load3(&buffer[1 + sizeof(FloatType)])) == tmp.values[1]);
+	CHECK(vector_get_y((Vector4Type)vector_load3(&buffer[1 + sizeof(FloatType)])) == tmp.values[2]);
+	CHECK(vector_get_z((Vector4Type)vector_load3(&buffer[1 + sizeof(FloatType)])) == tmp.values[3]);
+	CHECK(vector_get_w((Vector4Type)vector_load3(&buffer[1 + sizeof(FloatType)])) == FloatType(0.0));
 
 	CHECK(vector_get_x(quat_to_vector(identity)) == quat_get_x(identity));
 	CHECK(vector_get_y(quat_to_vector(identity)) == quat_get_y(identity));


### PR DESCRIPTION
When AVX isn't present, not zeroing requires 2 instructions: load + shuffle.
This ensures all partial load functions are consistent in behavior.