### PR TITLE
fix(core): avoid enabling NEON when just __arm__ is present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Significant changes per release
 
+## 2.1.1
+
+*  Avoid enabling NEON when just `__arm__` is present
+
 ## 2.1.0
 
 *  Force inlined most functions to improve MSVC code generation

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 2.1.0.{build}
+version: 2.1.1.{build}
 
 environment:
   PYTHON: "C:\\Python36-x64\\python.exe"

--- a/includes/rtm/impl/detect_arch.h
+++ b/includes/rtm/impl/detect_arch.h
@@ -33,6 +33,6 @@
 	#define RTM_ARCH_X86
 #elif defined(_M_ARM64) || defined(__aarch64__)
 	#define RTM_ARCH_ARM64
-#elif defined(_M_ARM) || defined(__ARM_NEON) || defined(__arm__)
+#elif defined(_M_ARM) || defined(__ARM_NEON)
 	#define RTM_ARCH_ARM
 #endif

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,7 +2,7 @@ sonar.organization=nfrechette-github
 
 sonar.projectKey=nfrechette_rtm
 sonar.projectName=Realtime Math
-sonar.projectVersion=2.1.0
+sonar.projectVersion=2.1.1
 
 sonar.sources=includes,tests/sources,tests/main_generic
 


### PR DESCRIPTION
NEON isn't always enabled and it can cause compilation failures.