### PR TITLE
fix: declare variable 'constants3_' only if RTM_NEON64_INTRINSICS macro defined

### DIFF
--- a/tools/bench/sources/bench_scalar_sin.cpp
+++ b/tools/bench/sources/bench_scalar_sin.cpp
@@ -100,6 +100,7 @@ RTM_FORCE_NOINLINE float RTM_SIMD_CALL scalar_sin_sse2(float input) RTM_NO_EXCEP
 }
 #endif
 
+#if defined(RTM_NEON64_INTRINSICS)
 alignas(64) static constexpr float constants3_[12] =
 {
 	2.7521557770526783e-6F, rtm::constants::one_div_two_pi(),
@@ -111,7 +112,6 @@ alignas(64) static constexpr float constants3_[12] =
 	1.0F, 1.0F,
 };
 
-#if defined(RTM_NEON64_INTRINSICS)
 RTM_FORCE_NOINLINE float RTM_SIMD_CALL scalar_sin_neon64(float input) RTM_NO_EXCEPT
 {
 	// Use a degree 11 minimax approximation polynomial


### PR DESCRIPTION
Otherwise compilation error "error: unused variable 'constants3_'" occurs:

```
/mnt/c/Work/projects/rtm/tools/bench/sources/bench_scalar_sin.cpp:103:36: error: unused variable 'constants3_' [-Werror,-Wunused-const-variable]
alignas(64) static constexpr float constants3_[12] =
                                   ^
1 error generated.
```