### PR TITLE
build: disable /MP option on Windows for compilers other than Microsoft Visual C++

### DIFF
--- a/cmake/CMakeCompiler.cmake
+++ b/cmake/CMakeCompiler.cmake
@@ -1,14 +1,16 @@
 cmake_minimum_required (VERSION 3.2)
 
 macro(setup_default_compiler_flags _project_name)
-	if(MSVC)
+	if(MSVC) # That's also clang-cl
 		# Replace some default compiler switches and add new ones
 		STRING(REPLACE "/GR" "" CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS})			# Disable RTTI
 		STRING(REPLACE "/W3" "/W4" CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS})		# Bump warnings to W4
 		target_compile_options(${_project_name} PRIVATE /Zi)				# Add debug info
 		target_compile_options(${_project_name} PRIVATE /Oi)				# Generate intrinsic functions
 		target_compile_options(${_project_name} PRIVATE /WX)				# Treat warnings as errors
-		target_compile_options(${_project_name} PRIVATE /MP)				# Enable parallel compilation
+		if (CMAKE_CXX_COMPILER_ID MATCHES "MSVC") # no Clang no Intel
+			target_compile_options(${_project_name} PRIVATE /MP)            # Enable parallel compilation
+		endif ()
 
 		if(MSVC_VERSION GREATER 1900)
 			# VS2017 and above


### PR DESCRIPTION
You state [in README](https://github.com/nfrechette/rtm#supported-platforms)  that `Windows VS2019 with clang9 x86 and x64` is a supported platform. However, the attempt to compile the _benchmark_ with it results in the following error:

```
[ 43%] Building CXX object tools/bench/main_generic/CMakeFiles/rtm_bench.dir/__/sources/bench_quat_conjugate.cpp.obj
clang-cl: error: argument unused during compilation: '/MP' [-Werror,-Wunused-command-line-argument]
NMAKE : fatal error U1077: 'C:\PROGRA~1\LLVM\bin\clang-cl.exe' : return code '0x1'
Stop.
NMAKE : fatal error U1077: '"C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC\Tools\MSVC\14.29.30133\bin\HostX86\x64\nmake.exe"' : return code '0x2'
Stop.
NMAKE : fatal error U1077: '"C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC\Tools\MSVC\14.29.30133\bin\HostX86\x64\nmake.exe"' : return code '0x2'
Stop.
NMAKE : fatal error U1077: '"C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC\Tools\MSVC\14.29.30133\bin\HostX86\x64\nmake.exe"' : return code '0x2'
Stop.
```

So, according to that [conversation](https://github.com/pybind/pybind11/pull/2824), it needs to disable `/MP` option for compilers other than Microsoft Visual C++ in case of Windows.