### PR TITLE
build: enable exceptions for clang-cl

### DIFF
--- a/tests/main_generic/CMakeLists.txt
+++ b/tests/main_generic/CMakeLists.txt
@@ -29,8 +29,8 @@ catch_discover_tests(${PROJECT_NAME})
 setup_default_compiler_flags(${PROJECT_NAME})
 
 if(MSVC)
-	if(CPU_INSTRUCTION_SET MATCHES "arm64")
-		# Exceptions are not enabled by default for ARM targets, enable them
+	if(CPU_INSTRUCTION_SET MATCHES "arm64" OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+		# Exceptions are not enabled by default for ARM targets and clang-cl, enable them
 		target_compile_options(${PROJECT_NAME} PRIVATE /EHsc)
 	endif()
 endif()


### PR DESCRIPTION
You state [in README](https://github.com/nfrechette/rtm#supported-platforms)  that `Windows VS2019 with clang9 x86 and x64` is a supported platform. However, the attempt to compile the _tests_ with it results in the following error:

```
[  0%] Building CXX object tests/main_generic/CMakeFiles/rtm_unit_tests.dir/__/sources/test_constants.cpp.obj
In file included from C:\Work\projects\rtm\tests\sources\test_constants.cpp:28:
In file included from C:\Work\projects\rtm\tests\main_generic\..\..\includes\rtm/scalarf.h:29:
In file included from C:\Work\projects\rtm\tests\main_generic\..\..\includes\rtm/macros.h:27:
In file included from C:\Work\projects\rtm\tests\main_generic\..\..\includes\rtm/math.h:115:
C:\Work\projects\rtm\tests\main_generic\..\..\includes\rtm/impl/error.h(140,6): error: cannot use 'throw' with exceptions disabled
                                        throw runtime_assert(std::string(&buffer[0], count));
                                        ^
C:\Work\projects\rtm\tests\main_generic\..\..\includes\rtm/impl/error.h(142,6): error: cannot use 'throw' with exceptions disabled
                                        throw runtime_assert("Failed to format assert message!\n");
                                        ^
2 errors generated.
NMAKE : fatal error U1077: 'C:\PROGRA~1\LLVM\bin\clang-cl.exe' : return code '0x1'
Stop.
NMAKE : fatal error U1077: '"C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC\Tools\MSVC\14.29.30133\bin\HostX86\x64\nmake.exe"' : return code '0x2'
Stop.
NMAKE : fatal error U1077: '"C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC\Tools\MSVC\14.29.30133\bin\HostX86\x64\nmake.exe"' : return code '0x2'
Stop.
NMAKE : fatal error U1077: '"C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC\Tools\MSVC\14.29.30133\bin\HostX86\x64\nmake.exe"' : return code '0x2'
Stop.
```

So, according to that [conversation](https://github.com/catchorg/Catch2/issues/1113), it needs to enable `/EHs` option for clang-cl, too.