### PR TITLE
fix(quat): ensure deterministic output on ARM64

### DIFF
--- a/includes/rtm/impl/detect_features.h
+++ b/includes/rtm/impl/detect_features.h
@@ -105,3 +105,19 @@
 		#define RTM_IMPL_VSQRT_SUPPORTED
 	#endif
 #endif
+
+//////////////////////////////////////////////////////////////////////////
+// Helper macro to determine if vfmss_laneq_f32 is supported (ARM64 only)
+//////////////////////////////////////////////////////////////////////////
+#if defined(RTM_ARCH_ARM64) && !defined(RTM_IMPL_VFMSS_SUPPORTED)
+	#if defined(RTM_COMPILER_MSVC)
+		#if defined(vfmss_laneq_f32)
+			// Support was introduced in VS2019
+			// MSVC uses defines for the ARM intrinsics, use them to perform feature detection
+			#define RTM_IMPL_VFMSS_SUPPORTED
+		#endif
+	#else
+		// Always enable with GCC and clang for now
+		#define RTM_IMPL_VFMSS_SUPPORTED
+	#endif
+#endif

--- a/includes/rtm/packing/quatf.h
+++ b/includes/rtm/packing/quatf.h
@@ -84,7 +84,7 @@ namespace rtm
 		__m128 result_wyzx = _mm_move_ss(input_wyzx, w);
 		return _mm_shuffle_ps(result_wyzx, result_wyzx, _MM_SHUFFLE(0, 2, 1, 3));
 #endif
-#elif defined(RTM_NEON64_INTRINSICS)
+#elif defined(RTM_NEON64_INTRINSICS) && defined(RTM_IMPL_VFMSS_SUPPORTED)
 		// 1.0 - (x * x)
 		float result = vfmss_laneq_f32(1.0F, vgetq_lane_f32(input, 0), input, 0);
 		// result - (y * y)


### PR DESCRIPTION
Clang 14 started fusing separate mul/sub instructions which impacts
accuracy. Switching to intrinsics to ensure consistent results across
versions and tool chains.