### PR TITLE
feat: optimize vector_mix with NEON

### DIFF
--- a/includes/rtm/vector4f.h
+++ b/includes/rtm/vector4f.h
@@ -2473,7 +2473,8 @@ namespace rtm
 		// Combine our masks to determine if we should return the original value
 		uint32x4_t use_original_input = vorrq_u32(is_input_large, is_nan);
 
-		uint32x4_t sign = vandq_u32(vreinterpretq_u32_f32(input), vdupq_n_f32(-0.0F));
+        uint32x4_t sign_mask = vreinterpretq_u32_f32(vdupq_n_f32(-0.0F));
+		uint32x4_t sign = vandq_u32(vreinterpretq_u32_f32(input), sign_mask);
 
 		// For positive values, we add a bias of 0.5.
 		// For negative values, we add a bias of -0.5.
@@ -2528,7 +2529,8 @@ namespace rtm
 #elif defined(RTM_NEON64_INTRINSICS)
 		return vrndnq_f32(input);
 #elif defined(RTM_NEON_INTRINSICS)
-		uint32x4_t sign = vandq_u32(vreinterpretq_u32_f32(input), vdupq_n_f32(-0.0F));
+        uint32x4_t sign_mask = vreinterpretq_u32_f32(vdupq_n_f32(-0.0F));
+		uint32x4_t sign = vandq_u32(vreinterpretq_u32_f32(input), sign_mask);
 
 		// We add the largest integer that a 32 bit floating point number can represent and subtract it afterwards.
 		// This relies on the fact that if we had a fractional part, the new value cannot be represented accurately

--- a/tools/bench/sources/bench_vector_round_bankers.cpp
+++ b/tools/bench/sources/bench_vector_round_bankers.cpp
@@ -71,7 +71,8 @@ RTM_FORCE_NOINLINE vector4f RTM_SIMD_CALL vector_round_bankers_neon64(vector4f_a
 #if defined(RTM_NEON_INTRINSICS)
 RTM_FORCE_NOINLINE vector4f RTM_SIMD_CALL vector_round_bankers_neon(vector4f_arg0 input) RTM_NO_EXCEPT
 {
-	uint32x4_t sign = vandq_u32(vreinterpretq_u32_f32(input), vdupq_n_f32(-0.0F));
+    uint32x4_t sign_mask = vreinterpretq_u32_f32(vdupq_n_f32(-0.0F));
+	uint32x4_t sign = vandq_u32(vreinterpretq_u32_f32(input), sign_mask);
 
 	// We add the largest integer that a 32 bit floating point number can represent and subtract it afterwards.
 	// This relies on the fact that if we had a fractional part, the new value cannot be represented accurately

--- a/tools/bench/sources/bench_vector_round_symmetric.cpp
+++ b/tools/bench/sources/bench_vector_round_symmetric.cpp
@@ -87,7 +87,8 @@ RTM_FORCE_NOINLINE vector4f RTM_SIMD_CALL vector_round_symmetric_neon(vector4f_a
 	// Combine our masks to determine if we should return the original value
 	uint32x4_t use_original_input = vorrq_u32(is_input_large, is_nan);
 
-	uint32x4_t sign = vandq_u32(vreinterpretq_u32_f32(input), vdupq_n_f32(-0.0F));
+    uint32x4_t sign_mask = vreinterpretq_u32_f32(vdupq_n_f32(-0.0F));
+	uint32x4_t sign = vandq_u32(vreinterpretq_u32_f32(input), sign_mask);
 
 	// For positive values, we add a bias of 0.5.
 	// For negative values, we add a bias of -0.5.


### PR DESCRIPTION
# Description

These are follow-up changes to PR #126 and issue #4. 

## Tests

Tested with `aarch64-linux-gnu-gcc` and `arm-linux-gnueabihf-gcc` cross compilers, `qemu-aarch64` and `qemu-arm` CPU emulators, WSL2 on Windows 11.

## Notes

- There is [vsetq_lane_f32](https://developer.arm.com/architectures/instruction-sets/intrinsics/vsetq_lane_f32) intrinsic for ARM64 to move an element from one vector to another. It was replaced with a combination of `vgetq_lane_f32` and `vsetq_lane_f32` intrinsics for compatibility with ARM, they shouldn't be this different according to [Godbolt](https://godbolt.org/z/oYodc78jP). But if necessary, a portable wrapper can be easily implemented.
- There is a common scenario when low/high doublewords of two vectors are combined together. However, I can't find appropriate intrinsic without interleaving. Instead of that, pattern `vcombine_f32(vget_low_f32(a), vget_low_f32(b));` is widely used in open-source and also results in the reasonable set of instructions according to [Godbolt](https://godbolt.org/z/h8nqccbaq).
- There is a rare scenario when `vector_dup_*` function is called and all components are the same. Not sure that this case should be supported within `vector_mix` scope, nevertheless I added support for this as an example.
- There is no `_mm_shuffle_*` equivalent of SSE intrinsic for NEON, probably generic implementation with the use of `__builtin_shufflevector` should be added wherever possible.
- I don't have a chance to build benchmarks using cross compilers and therefore can't make measurements.
