### PR TITLE
refactor(scalar): defining param as const by renaming it to scalarf_arg0

### DIFF
--- a/includes/rtm/scalarf.h
+++ b/includes/rtm/scalarf.h
@@ -1038,7 +1038,7 @@ namespace rtm
 	// The result's [y] component contains cos(angle).
 	// [zw] are undefined.
 	//////////////////////////////////////////////////////////////////////////
-	RTM_DISABLE_SECURITY_COOKIE_CHECK inline vector4f RTM_SIMD_CALL scalar_sincos(scalarf angle) RTM_NO_EXCEPT
+	RTM_DISABLE_SECURITY_COOKIE_CHECK inline vector4f RTM_SIMD_CALL scalar_sincos(scalarf_arg0 angle) RTM_NO_EXCEPT
 	{
 		scalarf sin_ = scalar_sin(angle);
 		scalarf cos_ = scalar_cos(angle);


### PR DESCRIPTION
Hello @nfrechette, constant parameter declaration may have been missed, judging by typedef in headers.