### PR TITLE
fix: disable fast math with GCC

### DIFF
--- a/includes/rtm/impl/compiler_utils.h
+++ b/includes/rtm/impl/compiler_utils.h
@@ -31,14 +31,31 @@
 // compilation flags used. However, in some cases, certain options must be forced.
 // To do this, every header is wrapped in two macros to push and pop the necessary
 // pragmas.
+//
+// Options we use:
+//    - Disable fast math, it can hurt precision for little to no performance gain due to the high level of hand tuned optimizations.
 //////////////////////////////////////////////////////////////////////////
 #if defined(RTM_COMPILER_MSVC)
 	#define RTM_IMPL_FILE_PRAGMA_PUSH \
-		/* Disable fast math, it can hurt precision for little to no performance gain due to the heavy usage of intrinsics. */ \
 		__pragma(float_control(precise, on, push))
 
 	#define RTM_IMPL_FILE_PRAGMA_POP \
 		__pragma(float_control(pop))
+#elif defined(RTM_COMPILER_CLANG) && 0
+	// For some reason, clang doesn't appear to support disabling fast-math through pragmas
+	// See: https://github.com/llvm/llvm-project/issues/55392
+	#define RTM_IMPL_FILE_PRAGMA_PUSH \
+		_Pragma("float_control(precise, on, push)")
+
+	#define RTM_IMPL_FILE_PRAGMA_POP \
+		_Pragma("float_control(pop)")
+#elif defined(RTM_COMPILER_GCC)
+	#define RTM_IMPL_FILE_PRAGMA_PUSH \
+		_Pragma("GCC push_options") \
+		_Pragma("GCC optimize (\"no-fast-math\")")
+
+	#define RTM_IMPL_FILE_PRAGMA_POP \
+		_Pragma("GCC pop_options")
 #else
 	#define RTM_IMPL_FILE_PRAGMA_PUSH
 	#define RTM_IMPL_FILE_PRAGMA_POP

--- a/tests/sources/test_vector4_impl.h
+++ b/tests/sources/test_vector4_impl.h
@@ -527,8 +527,9 @@ void test_vector4_arithmetic_impl(const FloatType threshold)
 	CHECK(scalar_near_equal(vector_get_z(vector_vdot_result), scalar_dot_result, threshold));
 	CHECK(scalar_near_equal(vector_get_w(vector_vdot_result), scalar_dot_result, threshold));
 
-	CHECK(scalar_near_equal(scalar_dot<Vector4Type, FloatType>(test_value0, test_value0), vector_length_squared(test_value0), threshold));
-	CHECK(scalar_near_equal(scalar_dot<Vector4Type, FloatType>(test_value0, test_value0), scalar_cast(vector_length_squared(test_value0)), threshold));
+	const FloatType length_squared_threshold = FloatType(30.0);	// Input W has large values
+	CHECK(scalar_near_equal(scalar_dot<Vector4Type, FloatType>(test_value0, test_value0), vector_length_squared(test_value0), length_squared_threshold));
+	CHECK(scalar_near_equal(scalar_dot<Vector4Type, FloatType>(test_value0, test_value0), scalar_cast(vector_length_squared(test_value0)), length_squared_threshold));
 	const FloatType vector_length_squared3_ref = scalar_dot3<Vector4Type, FloatType>(test_value0, test_value0);
 	const FloatType vector_length_squared3_result = vector_length_squared3(test_value0);
 	CHECK(scalar_near_equal(vector_length_squared3_ref, vector_length_squared3_result, threshold));


### PR DESCRIPTION
It can hurt determinism with little to no performance gain due to the high level of hand tuned optimizations.