### PR TITLE
feat: impl qvs support

### DIFF
--- a/docs/types_supported.md
+++ b/docs/types_supported.md
@@ -32,9 +32,13 @@ Quaternions are 4D complex numbers commonly used to represent 3D rotations (when
 
 A QV represents an affine transform in two distinct parts: a rotation quaternion and a vector3 translation. This type is commonly used in video games as it is very fast to work with and more compact than a full affine matrix.
 
+## QVS (quaternion-vector-scalar)
+
+A QVS represents an affine transform in three distinct parts: a rotation quaternion, a vector4 translation, and a scalar scale. This type is commonly used in video games as it is very fast to work with and more compact than a full affine matrix. It represents uniform positive/negative scale through a single scalar value. When multiplying transforms of this type, scale combines as it would with matrices.
+
 ## QVV (quaternion-vector-vector)
 
-A QVV represents an affine transform in three distinct parts: a rotation quaternion, a vector3 scale, and a vector3 translation. This type is commonly used in video games as it is very fast to work with and more compact than a full affine matrix. It properly handles positive non-uniform scaling but negative scaling is a bit more problematic. A best effort is made by converting the quaternion to a matrix when necessary. If scale fidelity is important, consider using an affine matrix 3x4 instead.
+A QVV represents an affine transform in three distinct parts: a rotation quaternion, a vector3 translation, and a vector3 scale. This type is commonly used in video games as it is very fast to work with and more compact than a full affine matrix. It properly handles positive non-uniform scaling but negative scaling is a bit more problematic. A best effort is made by converting the quaternion to a matrix when necessary. If scale fidelity is important, consider using an affine matrix 3x4 instead. When multiplying transforms of this type, scale combines as it would with matrices.
 
 ## Matrix 3x3
 

--- a/includes/rtm/impl/detect_compiler.h
+++ b/includes/rtm/impl/detect_compiler.h
@@ -37,6 +37,7 @@
 	#define RTM_COMPILER_MSVC_2015	1900
 	#define RTM_COMPILER_MSVC_2017	1910
 	#define RTM_COMPILER_MSVC_2019	1920
+	#define RTM_COMPILER_MSVC_2022	1930
 
 	#if RTM_COMPILER_MSVC < RTM_COMPILER_MSVC_2015
 		#pragma message("Warning: This version of visual studio isn't officially supported")

--- a/includes/rtm/impl/qvs_common.h
+++ b/includes/rtm/impl/qvs_common.h
@@ -74,7 +74,7 @@ namespace rtm
 	RTM_DISABLE_SECURITY_COOKIE_CHECK RTM_FORCE_INLINE qvsd RTM_SIMD_CALL qvs_set(const quatd& rotation, const vector4d& translation, const scalard& scale) RTM_NO_EXCEPT
 	{
 		const vector4d translation_scale = vector_set_w(translation, scale);
-		return qvsf{ rotation, translation_scale };
+		return qvsd{ rotation, translation_scale };
 	}
 #endif
 

--- a/includes/rtm/impl/qvs_common.h
+++ b/includes/rtm/impl/qvs_common.h
@@ -1,0 +1,114 @@
+#pragma once
+
+////////////////////////////////////////////////////////////////////////////////
+// The MIT License (MIT)
+//
+// Copyright (c) 2023 Nicholas Frechette & Realtime Math contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+////////////////////////////////////////////////////////////////////////////////
+
+#include "rtm/math.h"
+#include "rtm/version.h"
+#include "rtm/quatd.h"
+#include "rtm/quatf.h"
+#include "rtm/vector4d.h"
+#include "rtm/vector4f.h"
+#include "rtm/impl/compiler_utils.h"
+
+RTM_IMPL_FILE_PRAGMA_PUSH
+
+namespace rtm
+{
+	RTM_IMPL_VERSION_NAMESPACE_BEGIN
+
+	//////////////////////////////////////////////////////////////////////////
+	// Creates a QVS transform from a rotation quaternion, a translation, and scalar scale.
+	//////////////////////////////////////////////////////////////////////////
+	RTM_DISABLE_SECURITY_COOKIE_CHECK RTM_FORCE_INLINE qvsf RTM_SIMD_CALL qvs_set(quatf_arg0 rotation, vector4f_arg1 translation, float scale) RTM_NO_EXCEPT
+	{
+		const vector4f translation_scale = vector_set_w(translation, scale);
+		return qvsf{ rotation, translation_scale };
+	}
+
+#if defined(RTM_SSE2_INTRINSICS)
+	//////////////////////////////////////////////////////////////////////////
+	// Creates a QVS transform from a rotation quaternion, a translation, and scalar scale.
+	//////////////////////////////////////////////////////////////////////////
+	RTM_DISABLE_SECURITY_COOKIE_CHECK RTM_FORCE_INLINE qvsf RTM_SIMD_CALL qvs_set(quatf_arg0 rotation, vector4f_arg1 translation, scalarf_arg2 scale) RTM_NO_EXCEPT
+	{
+		const vector4f translation_scale = vector_set_w(translation, scale);
+		return qvsf{ rotation, translation_scale };
+	}
+#endif
+
+	//////////////////////////////////////////////////////////////////////////
+	// Creates a QVS transform from a rotation quaternion, a translation, and scale scale.
+	//////////////////////////////////////////////////////////////////////////
+	RTM_DISABLE_SECURITY_COOKIE_CHECK RTM_FORCE_INLINE qvsd RTM_SIMD_CALL qvs_set(const quatd& rotation, const vector4d& translation, double scale) RTM_NO_EXCEPT
+	{
+		const vector4d translation_scale = vector_set_w(translation, scale);
+		return qvsd{ rotation, translation_scale };
+	}
+
+#if defined(RTM_SSE2_INTRINSICS)
+	//////////////////////////////////////////////////////////////////////////
+	// Creates a QVS transform from a rotation quaternion, a translation, and scalar scale.
+	//////////////////////////////////////////////////////////////////////////
+	RTM_DISABLE_SECURITY_COOKIE_CHECK RTM_FORCE_INLINE qvsd RTM_SIMD_CALL qvs_set(const quatd& rotation, const vector4d& translation, const scalard& scale) RTM_NO_EXCEPT
+	{
+		const vector4d translation_scale = vector_set_w(translation, scale);
+		return qvsf{ rotation, translation_scale };
+	}
+#endif
+
+	namespace rtm_impl
+	{
+		//////////////////////////////////////////////////////////////////////////
+		// This is a helper struct to allow a single consistent API between
+		// various QVS transform types when the semantics are identical but the return
+		// type differs. Implicit coercion is used to return the desired value
+		// at the call site.
+		//////////////////////////////////////////////////////////////////////////
+		struct qvs_identity_impl
+		{
+			RTM_DISABLE_SECURITY_COOKIE_CHECK RTM_FORCE_INLINE RTM_SIMD_CALL operator qvsd() const RTM_NO_EXCEPT
+			{
+				return qvsd{ quat_identity(), vector_set(0.0, 0.0, 0.0, 1.0) };
+			}
+
+			RTM_DISABLE_SECURITY_COOKIE_CHECK RTM_FORCE_INLINE RTM_SIMD_CALL operator qvsf() const RTM_NO_EXCEPT
+			{
+				return qvsf{ quat_identity(), vector_set(0.0F, 0.0F, 0.0F, 1.0F) };
+			}
+		};
+	}
+
+	//////////////////////////////////////////////////////////////////////////
+	// Returns the identity QVS transform.
+	//////////////////////////////////////////////////////////////////////////
+	RTM_DISABLE_SECURITY_COOKIE_CHECK RTM_FORCE_INLINE constexpr rtm_impl::qvs_identity_impl RTM_SIMD_CALL qvs_identity() RTM_NO_EXCEPT
+	{
+		return rtm_impl::qvs_identity_impl();
+	}
+
+	RTM_IMPL_VERSION_NAMESPACE_END
+}
+
+RTM_IMPL_FILE_PRAGMA_POP

--- a/includes/rtm/impl/type_args.h
+++ b/includes/rtm/impl/type_args.h
@@ -94,6 +94,10 @@ namespace rtm
 	using qvf_arg1 = const qvf;
 	using qvf_argn = const qvf&;
 
+	using qvsf_arg0 = const qvsf;
+	using qvsf_arg1 = const qvsf;
+	using qvsf_argn = const qvsf&;
+
 	using qvvf_arg0 = const qvvf;
 	using qvvf_arg1 = const qvvf;
 	using qvvf_argn = const qvvf&;
@@ -171,6 +175,10 @@ namespace rtm
 	using qvf_arg1 = const qvf;
 	using qvf_argn = const qvf&;
 
+	using qvsf_arg0 = const qvsf;
+	using qvsf_arg1 = const qvsf;
+	using qvsf_argn = const qvsf&;
+
 	using qvvf_arg0 = const qvvf;
 	using qvvf_arg1 = const qvvf;
 	using qvvf_argn = const qvvf&;
@@ -246,6 +254,10 @@ namespace rtm
 	using qvf_arg1 = const qvf&;
 	using qvf_argn = const qvf&;
 
+	using qvsf_arg0 = const qvsf&;
+	using qvsf_arg1 = const qvsf&;
+	using qvsf_argn = const qvsf&;
+
 	using qvvf_arg0 = const qvvf&;
 	using qvvf_arg1 = const qvvf&;
 	using qvvf_argn = const qvvf&;
@@ -320,6 +332,10 @@ namespace rtm
 	using qvf_arg0 = const qvf&;
 	using qvf_arg1 = const qvf&;
 	using qvf_argn = const qvf&;
+
+	using qvsf_arg0 = const qvsf&;
+	using qvsf_arg1 = const qvsf&;
+	using qvsf_argn = const qvsf&;
 
 	using qvvf_arg0 = const qvvf&;
 	using qvvf_arg1 = const qvvf&;
@@ -401,6 +417,10 @@ namespace rtm
 	using qvf_arg1 = const qvf&;
 	using qvf_argn = const qvf&;
 
+	using qvsf_arg0 = const qvsf&;
+	using qvsf_arg1 = const qvsf&;
+	using qvsf_argn = const qvsf&;
+
 	using qvvf_arg0 = const qvvf&;
 	using qvvf_arg1 = const qvvf&;
 	using qvvf_argn = const qvvf&;
@@ -471,6 +491,10 @@ namespace rtm
 	using qvf_arg0 = const qvf&;
 	using qvf_arg1 = const qvf&;
 	using qvf_argn = const qvf&;
+
+	using qvsf_arg0 = const qvsf&;
+	using qvsf_arg1 = const qvsf&;
+	using qvsf_argn = const qvsf&;
 
 	using qvvf_arg0 = const qvvf&;
 	using qvvf_arg1 = const qvvf&;

--- a/includes/rtm/matrix3x4d.h
+++ b/includes/rtm/matrix3x4d.h
@@ -28,6 +28,7 @@
 #include "rtm/math.h"
 #include "rtm/matrix3x3d.h"
 #include "rtm/quatd.h"
+#include "rtm/qvsd.h"
 #include "rtm/vector4d.h"
 #include "rtm/version.h"
 #include "rtm/impl/compiler_utils.h"
@@ -88,6 +89,42 @@ namespace rtm
 	RTM_DISABLE_SECURITY_COOKIE_CHECK inline matrix3x4d matrix_from_qv(const qvd& transform) RTM_NO_EXCEPT
 	{
 		return matrix_from_qv(transform.rotation, transform.translation);
+	}
+
+	//////////////////////////////////////////////////////////////////////////
+	// Sets a 3x4 affine matrix from a rotation quaternion, translation, and scalar scale.
+	//////////////////////////////////////////////////////////////////////////
+	RTM_DISABLE_SECURITY_COOKIE_CHECK inline matrix3x4d matrix_from_qvs(const quatd& quat, const vector4d& translation, double scale) RTM_NO_EXCEPT
+	{
+		RTM_ASSERT(quat_is_normalized(quat), "Quaternion is not normalized");
+
+		const double x2 = quat_get_x(quat) + quat_get_x(quat);
+		const double y2 = quat_get_y(quat) + quat_get_y(quat);
+		const double z2 = quat_get_z(quat) + quat_get_z(quat);
+		const double xx = quat_get_x(quat) * x2;
+		const double xy = quat_get_x(quat) * y2;
+		const double xz = quat_get_x(quat) * z2;
+		const double yy = quat_get_y(quat) * y2;
+		const double yz = quat_get_y(quat) * z2;
+		const double zz = quat_get_z(quat) * z2;
+		const double wx = quat_get_w(quat) * x2;
+		const double wy = quat_get_w(quat) * y2;
+		const double wz = quat_get_w(quat) * z2;
+
+		const scalard scale_s = scalar_set(scale);
+
+		const vector4d x_axis = vector_mul(vector_set(1.0 - (yy + zz), xy + wz, xz - wy, 0.0), scale_s);
+		const vector4d y_axis = vector_mul(vector_set(xy - wz, 1.0 - (xx + zz), yz + wx, 0.0), scale_s);
+		const vector4d z_axis = vector_mul(vector_set(xz + wy, yz - wx, 1.0 - (xx + yy), 0.0), scale_s);
+		return matrix3x4d{ x_axis, y_axis, z_axis, translation };
+	}
+
+	//////////////////////////////////////////////////////////////////////////
+	// Converts a QVS transform into a 3x4 affine matrix.
+	//////////////////////////////////////////////////////////////////////////
+	RTM_DISABLE_SECURITY_COOKIE_CHECK inline matrix3x4d matrix_from_qvs(const qvsd& transform) RTM_NO_EXCEPT
+	{
+		return matrix_from_qvs(transform.rotation, transform.translation_scale, qvs_get_scale(transform));
 	}
 
 	//////////////////////////////////////////////////////////////////////////

--- a/includes/rtm/qvsd.h
+++ b/includes/rtm/qvsd.h
@@ -259,7 +259,7 @@ namespace rtm
 	// Per component spherical interpolation of the two inputs at the specified alpha.
 	// See quat_slerp(..)
 	//////////////////////////////////////////////////////////////////////////
-	RTM_DISABLE_SECURITY_COOKIE_CHECK RTM_FORCE_INLINE qvsd qvv_slerp_no_scale(const qvsd& start, const qvsd& end, const scalard& alpha) RTM_NO_EXCEPT
+	RTM_DISABLE_SECURITY_COOKIE_CHECK RTM_FORCE_INLINE qvsd qvs_slerp_no_scale(const qvsd& start, const qvsd& end, const scalard& alpha) RTM_NO_EXCEPT
 	{
 		const quatd rotation = quat_slerp(start.rotation, end.rotation, alpha);
 		const vector4d translation_scale_lerp = vector_lerp(start.translation_scale, end.translation_scale, alpha);

--- a/includes/rtm/qvsd.h
+++ b/includes/rtm/qvsd.h
@@ -264,7 +264,7 @@ namespace rtm
 		const quatd rotation = quat_slerp(start.rotation, end.rotation, alpha);
 		const vector4d translation_scale_lerp = vector_lerp(start.translation_scale, end.translation_scale, alpha);
 		const vector4d translation_scale = vector_mix<mix4::x, mix4::y, mix4::z, mix4::d>(translation_scale_lerp, start.translation_scale);
-		return qvsf{ rotation, translation_scale };
+		return qvsd{ rotation, translation_scale };
 	}
 #endif
 

--- a/includes/rtm/qvsd.h
+++ b/includes/rtm/qvsd.h
@@ -1,0 +1,282 @@
+#pragma once
+
+////////////////////////////////////////////////////////////////////////////////
+// The MIT License (MIT)
+//
+// Copyright (c) 2023 Nicholas Frechette & Realtime Math contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+////////////////////////////////////////////////////////////////////////////////
+
+#include "rtm/math.h"
+#include "rtm/quatd.h"
+#include "rtm/vector4d.h"
+#include "rtm/version.h"
+#include "rtm/impl/compiler_utils.h"
+#include "rtm/impl/qvs_common.h"
+
+RTM_IMPL_FILE_PRAGMA_PUSH
+
+namespace rtm
+{
+	RTM_IMPL_VERSION_NAMESPACE_BEGIN
+
+	//////////////////////////////////////////////////////////////////////////
+	// Casts a QVS transform float64 variant to a float32 variant.
+	//////////////////////////////////////////////////////////////////////////
+	RTM_DISABLE_SECURITY_COOKIE_CHECK RTM_FORCE_INLINE qvsd RTM_SIMD_CALL qvs_cast(qvsf_arg0 input) RTM_NO_EXCEPT
+	{
+		return qvsd{ quat_cast(input.rotation), vector_cast(input.translation_scale) };
+	}
+
+	//////////////////////////////////////////////////////////////////////////
+	// Returns the rotation part of a QVS transform.
+	//////////////////////////////////////////////////////////////////////////
+	RTM_DISABLE_SECURITY_COOKIE_CHECK RTM_FORCE_INLINE quatd qvs_get_rotation(const qvsd& input) RTM_NO_EXCEPT
+	{
+		return input.rotation;
+	}
+
+	//////////////////////////////////////////////////////////////////////////
+	// Returns the translation part of a QVS transform.
+	//////////////////////////////////////////////////////////////////////////
+	RTM_DISABLE_SECURITY_COOKIE_CHECK RTM_FORCE_INLINE vector4d qvs_get_translation(const qvsd& input) RTM_NO_EXCEPT
+	{
+		return input.translation_scale;
+	}
+
+	//////////////////////////////////////////////////////////////////////////
+	// Returns the scale part of a QVS transform.
+	//////////////////////////////////////////////////////////////////////////
+	RTM_DISABLE_SECURITY_COOKIE_CHECK RTM_FORCE_INLINE constexpr rtm_impl::vector4d_vector_get_w qvs_get_scale(const qvsd& input) RTM_NO_EXCEPT
+	{
+		return rtm_impl::vector4d_vector_get_w{ input.translation_scale };
+	}
+
+	//////////////////////////////////////////////////////////////////////////
+	// Multiplies two QVS transforms.
+	// Multiplication order is as follow: local_to_world = qvs_mul(local_to_object, object_to_world)
+	//////////////////////////////////////////////////////////////////////////
+	RTM_DISABLE_SECURITY_COOKIE_CHECK inline qvsd qvs_mul(const qvsd& lhs, const qvsd& rhs) RTM_NO_EXCEPT
+	{
+		const vector4d rhs_scale = vector_dup_w(rhs.translation_scale);
+
+		const quatd rotation = quat_mul(lhs.rotation, rhs.rotation);
+		const vector4d translation = vector_add(quat_mul_vector3(vector_mul(lhs.translation_scale, rhs_scale), rhs.rotation), rhs.translation_scale);
+		const vector4d scale_w = vector_mul(lhs.translation_scale, rhs.translation_scale);
+		const vector4d translation_scale = vector_mix<mix4::x, mix4::y, mix4::z, mix4::d>(translation, scale_w);
+
+		return qvsd{ rotation, translation_scale };
+	}
+
+	//////////////////////////////////////////////////////////////////////////
+	// Multiplies two QVS transforms ignoring scale.
+	// The resulting QVS transform will have the LHS scale.
+	// Multiplication order is as follow: local_to_world = qvs_mul(local_to_object, object_to_world)
+	//////////////////////////////////////////////////////////////////////////
+	RTM_DISABLE_SECURITY_COOKIE_CHECK inline qvsd qvs_mul_no_scale(const qvsd& lhs, const qvsd& rhs) RTM_NO_EXCEPT
+	{
+		const quatd rotation = quat_mul(lhs.rotation, rhs.rotation);
+		const vector4d translation = vector_add(quat_mul_vector3(lhs.translation_scale, rhs.rotation), rhs.translation_scale);
+		const vector4d translation_scale = vector_mix<mix4::x, mix4::y, mix4::z, mix4::d>(translation, lhs.translation_scale);
+
+		return qvsd{ rotation, translation_scale };
+	}
+
+	//////////////////////////////////////////////////////////////////////////
+	// Multiplies a QVS transform and a 3D point.
+	// Multiplication order is as follow: world_position = qvs_mul_point3(local_position, local_to_world)
+	//////////////////////////////////////////////////////////////////////////
+	RTM_DISABLE_SECURITY_COOKIE_CHECK inline vector4d qvs_mul_point3(const vector4d& point, const qvsd& qvs) RTM_NO_EXCEPT
+	{
+		const vector4d scale = vector_dup_w(qvs.translation_scale);
+		return vector_add(quat_mul_vector3(vector_mul(scale, point), qvs.rotation), qvs.translation_scale);
+	}
+
+	//////////////////////////////////////////////////////////////////////////
+	// Multiplies a QVS transform and a 3D point ignoring 3D scale.
+	// Multiplication order is as follow: world_position = qvs_mul_point3_no_scale(local_position, local_to_world)
+	//////////////////////////////////////////////////////////////////////////
+	RTM_DISABLE_SECURITY_COOKIE_CHECK inline vector4d qvs_mul_point3_no_scale(const vector4d& point, const qvsd& qvs) RTM_NO_EXCEPT
+	{
+		return vector_add(quat_mul_vector3(point, qvs.rotation), qvs.translation_scale);
+	}
+
+	//////////////////////////////////////////////////////////////////////////
+	// Returns the inverse of the input QVS transform.
+	//////////////////////////////////////////////////////////////////////////
+	RTM_DISABLE_SECURITY_COOKIE_CHECK inline qvsd qvs_inverse(const qvsd& input) RTM_NO_EXCEPT
+	{
+		const quatd inv_rotation = quat_conjugate(input.rotation);
+		const vector4d inv_scale_w = vector_reciprocal(input.translation_scale);
+		const vector4d inv_scale = vector_dup_w(inv_scale_w);
+		const vector4d inv_translation = vector_neg(quat_mul_vector3(vector_mul(input.translation_scale, inv_scale), inv_rotation));
+		const vector4d inv_translation_scale = vector_mix<mix4::x, mix4::y, mix4::z, mix4::d>(inv_translation, inv_scale_w);
+
+		return qvsd{ inv_rotation, inv_translation_scale };
+	}
+
+	//////////////////////////////////////////////////////////////////////////
+	// Returns the inverse of the input QVS transform ignoring 3D scale.
+	// The resulting QVS transform will have the input scale.
+	//////////////////////////////////////////////////////////////////////////
+	RTM_DISABLE_SECURITY_COOKIE_CHECK inline qvsd qvs_inverse_no_scale(const qvsd& input) RTM_NO_EXCEPT
+	{
+		const quatd inv_rotation = quat_conjugate(input.rotation);
+		const vector4d inv_translation = vector_neg(quat_mul_vector3(input.translation_scale, inv_rotation));
+		const vector4d inv_translation_scale = vector_mix<mix4::x, mix4::y, mix4::z, mix4::d>(inv_translation, input.translation_scale);
+
+		return qvsd{ inv_rotation, inv_translation_scale };
+	}
+
+	//////////////////////////////////////////////////////////////////////////
+	// Returns a QVS transforms with the rotation part normalized.
+	//////////////////////////////////////////////////////////////////////////
+	RTM_DISABLE_SECURITY_COOKIE_CHECK RTM_FORCE_INLINE qvsd qvs_normalize(const qvsd& input) RTM_NO_EXCEPT
+	{
+		const quatd rotation = quat_normalize(input.rotation);
+		return qvsd{ rotation, input.translation_scale };
+	}
+
+	//////////////////////////////////////////////////////////////////////////
+	// Per component linear interpolation of the two inputs at the specified alpha.
+	// The formula used is: ((1.0 - alpha) * start) + (alpha * end).
+	// Interpolation is stable and will return 'start' when alpha is 0.0 and 'end' when it is 1.0.
+	// This is the same instruction count when FMA is present but it might be slightly slower
+	// due to the extra multiplication compared to: start + (alpha * (end - start)).
+	//////////////////////////////////////////////////////////////////////////
+	RTM_DISABLE_SECURITY_COOKIE_CHECK RTM_FORCE_INLINE qvsd qvs_lerp(const qvsd& start, const qvsd& end, double alpha) RTM_NO_EXCEPT
+	{
+		const quatd rotation = quat_lerp(start.rotation, end.rotation, alpha);
+		const vector4d translation_scale = vector_lerp(start.translation_scale, end.translation_scale, alpha);
+		return qvsd{ rotation, translation_scale };
+	}
+
+#if defined(RTM_SSE2_INTRINSICS)
+	//////////////////////////////////////////////////////////////////////////
+	// Per component linear interpolation of the two inputs at the specified alpha.
+	// The formula used is: ((1.0 - alpha) * start) + (alpha * end).
+	// Interpolation is stable and will return 'start' when alpha is 0.0 and 'end' when it is 1.0.
+	// This is the same instruction count when FMA is present but it might be slightly slower
+	// due to the extra multiplication compared to: start + (alpha * (end - start)).
+	//////////////////////////////////////////////////////////////////////////
+	RTM_DISABLE_SECURITY_COOKIE_CHECK RTM_FORCE_INLINE qvsd qvs_lerp(const qvsd& start, const qvsd& end, const scalard& alpha) RTM_NO_EXCEPT
+	{
+		const quatd rotation = quat_lerp(start.rotation, end.rotation, alpha);
+		const vector4d translation_scale = vector_lerp(start.translation_scale, end.translation_scale, alpha);
+		return qvsd{ rotation, translation_scale };
+	}
+#endif
+
+	//////////////////////////////////////////////////////////////////////////
+	// Per component linear interpolation of the two inputs at the specified alpha.
+	// The formula used is: ((1.0 - alpha) * start) + (alpha * end).
+	// Interpolation is stable and will return 'start' when alpha is 0.0 and 'end' when it is 1.0.
+	// This is the same instruction count when FMA is present but it might be slightly slower
+	// due to the extra multiplication compared to: start + (alpha * (end - start)).
+	// The resulting QVV transform will have the start scale.
+	//////////////////////////////////////////////////////////////////////////
+	RTM_DISABLE_SECURITY_COOKIE_CHECK RTM_FORCE_INLINE qvsd qvs_lerp_no_scale(const qvsd& start, const qvsd& end, double alpha) RTM_NO_EXCEPT
+	{
+		const quatd rotation = quat_lerp(start.rotation, end.rotation, alpha);
+		const vector4d translation_scale_lerp = vector_lerp(start.translation_scale, end.translation_scale, alpha);
+		const vector4d translation_scale = vector_mix<mix4::x, mix4::y, mix4::z, mix4::d>(translation_scale_lerp, start.translation_scale);
+		return qvsd{ rotation, translation_scale };
+	}
+
+#if defined(RTM_SSE2_INTRINSICS)
+	//////////////////////////////////////////////////////////////////////////
+	// Per component linear interpolation of the two inputs at the specified alpha.
+	// The formula used is: ((1.0 - alpha) * start) + (alpha * end).
+	// Interpolation is stable and will return 'start' when alpha is 0.0 and 'end' when it is 1.0.
+	// This is the same instruction count when FMA is present but it might be slightly slower
+	// due to the extra multiplication compared to: start + (alpha * (end - start)).
+	// The resulting QVV transform will have the start scale.
+	//////////////////////////////////////////////////////////////////////////
+	RTM_DISABLE_SECURITY_COOKIE_CHECK RTM_FORCE_INLINE qvsd qvs_lerp_no_scale(const qvsd& start, const qvsd& end, const scalard& alpha) RTM_NO_EXCEPT
+	{
+		const quatd rotation = quat_lerp(start.rotation, end.rotation, alpha);
+		const vector4d translation_scale_lerp = vector_lerp(start.translation_scale, end.translation_scale, alpha);
+		const vector4d translation_scale = vector_mix<mix4::x, mix4::y, mix4::z, mix4::d>(translation_scale_lerp, start.translation_scale);
+		return qvsd{ rotation, translation_scale };
+	}
+#endif
+
+	//////////////////////////////////////////////////////////////////////////
+	// Per component spherical interpolation of the two inputs at the specified alpha.
+	// See quat_slerp(..)
+	//////////////////////////////////////////////////////////////////////////
+	RTM_DISABLE_SECURITY_COOKIE_CHECK RTM_FORCE_INLINE qvsd qvs_slerp(const qvsd& start, const qvsd& end, double alpha) RTM_NO_EXCEPT
+	{
+		const quatd rotation = quat_slerp(start.rotation, end.rotation, alpha);
+		const vector4d translation_scale = vector_lerp(start.translation_scale, end.translation_scale, alpha);
+		return qvsd{ rotation, translation_scale };
+	}
+
+#if defined(RTM_SSE2_INTRINSICS)
+	//////////////////////////////////////////////////////////////////////////
+	// Per component spherical interpolation of the two inputs at the specified alpha.
+	// See quat_slerp(..)
+	//////////////////////////////////////////////////////////////////////////
+	RTM_DISABLE_SECURITY_COOKIE_CHECK RTM_FORCE_INLINE qvsd qvs_slerp(const qvsd& start, const qvsd& end, const scalard& alpha) RTM_NO_EXCEPT
+	{
+		const quatd rotation = quat_slerp(start.rotation, end.rotation, alpha);
+		const vector4d translation_scale = vector_lerp(start.translation_scale, end.translation_scale, alpha);
+		return qvsd{ rotation, translation_scale };
+	}
+#endif
+
+	//////////////////////////////////////////////////////////////////////////
+	// Per component spherical interpolation of the two inputs at the specified alpha.
+	// See quat_slerp(..)
+	//////////////////////////////////////////////////////////////////////////
+	RTM_DISABLE_SECURITY_COOKIE_CHECK RTM_FORCE_INLINE qvsd qvs_slerp_no_scale(const qvsd& start, const qvsd& end, double alpha) RTM_NO_EXCEPT
+	{
+		const quatd rotation = quat_slerp(start.rotation, end.rotation, alpha);
+		const vector4d translation_scale_lerp = vector_lerp(start.translation_scale, end.translation_scale, alpha);
+		const vector4d translation_scale = vector_mix<mix4::x, mix4::y, mix4::z, mix4::d>(translation_scale_lerp, start.translation_scale);
+		return qvsd{ rotation, translation_scale };
+	}
+
+#if defined(RTM_SSE2_INTRINSICS)
+	//////////////////////////////////////////////////////////////////////////
+	// Per component spherical interpolation of the two inputs at the specified alpha.
+	// See quat_slerp(..)
+	//////////////////////////////////////////////////////////////////////////
+	RTM_DISABLE_SECURITY_COOKIE_CHECK RTM_FORCE_INLINE qvsd qvv_slerp_no_scale(const qvsd& start, const qvsd& end, const scalard& alpha) RTM_NO_EXCEPT
+	{
+		const quatd rotation = quat_slerp(start.rotation, end.rotation, alpha);
+		const vector4d translation_scale_lerp = vector_lerp(start.translation_scale, end.translation_scale, alpha);
+		const vector4d translation_scale = vector_mix<mix4::x, mix4::y, mix4::z, mix4::d>(translation_scale_lerp, start.translation_scale);
+		return qvsf{ rotation, translation_scale };
+	}
+#endif
+
+	//////////////////////////////////////////////////////////////////////////
+	// Returns true if the input QVS does not contain any NaN or Inf, otherwise false.
+	//////////////////////////////////////////////////////////////////////////
+	RTM_DISABLE_SECURITY_COOKIE_CHECK RTM_FORCE_INLINE bool qvs_is_finite(const qvsd& input) RTM_NO_EXCEPT
+	{
+		return quat_is_finite(input.rotation) && vector_is_finite(input.translation_scale);
+	}
+
+	RTM_IMPL_VERSION_NAMESPACE_END
+}
+
+RTM_IMPL_FILE_PRAGMA_POP

--- a/includes/rtm/qvsf.h
+++ b/includes/rtm/qvsf.h
@@ -1,0 +1,282 @@
+#pragma once
+
+////////////////////////////////////////////////////////////////////////////////
+// The MIT License (MIT)
+//
+// Copyright (c) 2023 Nicholas Frechette & Realtime Math contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+////////////////////////////////////////////////////////////////////////////////
+
+#include "rtm/math.h"
+#include "rtm/quatf.h"
+#include "rtm/vector4f.h"
+#include "rtm/version.h"
+#include "rtm/impl/compiler_utils.h"
+#include "rtm/impl/qvs_common.h"
+
+RTM_IMPL_FILE_PRAGMA_PUSH
+
+namespace rtm
+{
+	RTM_IMPL_VERSION_NAMESPACE_BEGIN
+
+	//////////////////////////////////////////////////////////////////////////
+	// Casts a QVS transform float64 variant to a float32 variant.
+	//////////////////////////////////////////////////////////////////////////
+	RTM_DISABLE_SECURITY_COOKIE_CHECK RTM_FORCE_INLINE qvsf RTM_SIMD_CALL qvs_cast(const qvsd& input) RTM_NO_EXCEPT
+	{
+		return qvsf{ quat_cast(input.rotation), vector_cast(input.translation_scale) };
+	}
+
+	//////////////////////////////////////////////////////////////////////////
+	// Returns the rotation part of a QVS transform.
+	//////////////////////////////////////////////////////////////////////////
+	RTM_DISABLE_SECURITY_COOKIE_CHECK RTM_FORCE_INLINE quatf RTM_SIMD_CALL qvs_get_rotation(qvsf_arg0 input) RTM_NO_EXCEPT
+	{
+		return input.rotation;
+	}
+
+	//////////////////////////////////////////////////////////////////////////
+	// Returns the translation part of a QVS transform.
+	//////////////////////////////////////////////////////////////////////////
+	RTM_DISABLE_SECURITY_COOKIE_CHECK RTM_FORCE_INLINE vector4f RTM_SIMD_CALL qvs_get_translation(qvsf_arg0 input) RTM_NO_EXCEPT
+	{
+		return input.translation_scale;
+	}
+
+	//////////////////////////////////////////////////////////////////////////
+	// Returns the scale part of a QVS transform.
+	//////////////////////////////////////////////////////////////////////////
+	RTM_DISABLE_SECURITY_COOKIE_CHECK RTM_FORCE_INLINE constexpr rtm_impl::vector4f_vector_get_w RTM_SIMD_CALL qvs_get_scale(qvsf_arg0 input) RTM_NO_EXCEPT
+	{
+		return rtm_impl::vector4f_vector_get_w{ input.translation_scale };
+	}
+
+	//////////////////////////////////////////////////////////////////////////
+	// Multiplies two QVS transforms.
+	// Multiplication order is as follow: local_to_world = qvs_mul(local_to_object, object_to_world)
+	//////////////////////////////////////////////////////////////////////////
+	RTM_DISABLE_SECURITY_COOKIE_CHECK inline qvsf RTM_SIMD_CALL qvs_mul(qvsf_arg0 lhs, qvsf_arg1 rhs) RTM_NO_EXCEPT
+	{
+		const vector4f rhs_scale = vector_dup_w(rhs.translation_scale);
+
+		const quatf rotation = quat_mul(lhs.rotation, rhs.rotation);
+		const vector4f translation = vector_add(quat_mul_vector3(vector_mul(lhs.translation_scale, rhs_scale), rhs.rotation), rhs.translation_scale);
+		const vector4f scale_w = vector_mul(lhs.translation_scale, rhs.translation_scale);
+		const vector4f translation_scale = vector_mix<mix4::x, mix4::y, mix4::z, mix4::d>(translation, scale_w);
+
+		return qvsf{ rotation, translation_scale };
+	}
+
+	//////////////////////////////////////////////////////////////////////////
+	// Multiplies two QVS transforms ignoring scale.
+	// The resulting QVS transform will have the LHS scale.
+	// Multiplication order is as follow: local_to_world = qvs_mul(local_to_object, object_to_world)
+	//////////////////////////////////////////////////////////////////////////
+	RTM_DISABLE_SECURITY_COOKIE_CHECK inline qvsf RTM_SIMD_CALL qvs_mul_no_scale(qvsf_arg0 lhs, qvsf_arg1 rhs) RTM_NO_EXCEPT
+	{
+		const quatf rotation = quat_mul(lhs.rotation, rhs.rotation);
+		const vector4f translation = vector_add(quat_mul_vector3(lhs.translation_scale, rhs.rotation), rhs.translation_scale);
+		const vector4f translation_scale = vector_mix<mix4::x, mix4::y, mix4::z, mix4::d>(translation, lhs.translation_scale);
+
+		return qvsf{ rotation, translation_scale };
+	}
+
+	//////////////////////////////////////////////////////////////////////////
+	// Multiplies a QVS transform and a 3D point.
+	// Multiplication order is as follow: world_position = qvs_mul_point3(local_position, local_to_world)
+	//////////////////////////////////////////////////////////////////////////
+	RTM_DISABLE_SECURITY_COOKIE_CHECK inline vector4f RTM_SIMD_CALL qvs_mul_point3(vector4f_arg0 point, qvsf_arg1 qvs) RTM_NO_EXCEPT
+	{
+		const vector4f scale = vector_dup_w(qvs.translation_scale);
+		return vector_add(quat_mul_vector3(vector_mul(scale, point), qvs.rotation), qvs.translation_scale);
+	}
+
+	//////////////////////////////////////////////////////////////////////////
+	// Multiplies a QVS transform and a 3D point ignoring 3D scale.
+	// Multiplication order is as follow: world_position = qvs_mul_point3_no_scale(local_position, local_to_world)
+	//////////////////////////////////////////////////////////////////////////
+	RTM_DISABLE_SECURITY_COOKIE_CHECK inline vector4f RTM_SIMD_CALL qvs_mul_point3_no_scale(vector4f_arg0 point, qvsf_arg1 qvs) RTM_NO_EXCEPT
+	{
+		return vector_add(quat_mul_vector3(point, qvs.rotation), qvs.translation_scale);
+	}
+
+	//////////////////////////////////////////////////////////////////////////
+	// Returns the inverse of the input QVS transform.
+	//////////////////////////////////////////////////////////////////////////
+	RTM_DISABLE_SECURITY_COOKIE_CHECK inline qvsf RTM_SIMD_CALL qvs_inverse(qvsf_arg0 input) RTM_NO_EXCEPT
+	{
+		const quatf inv_rotation = quat_conjugate(input.rotation);
+		const vector4f inv_scale_w = vector_reciprocal(input.translation_scale);
+		const vector4f inv_scale = vector_dup_w(inv_scale_w);
+		const vector4f inv_translation = vector_neg(quat_mul_vector3(vector_mul(input.translation_scale, inv_scale), inv_rotation));
+		const vector4f inv_translation_scale = vector_mix<mix4::x, mix4::y, mix4::z, mix4::d>(inv_translation, inv_scale_w);
+
+		return qvsf{ inv_rotation, inv_translation_scale };
+	}
+
+	//////////////////////////////////////////////////////////////////////////
+	// Returns the inverse of the input QVS transform ignoring 3D scale.
+	// The resulting QVS transform will have the input scale.
+	//////////////////////////////////////////////////////////////////////////
+	RTM_DISABLE_SECURITY_COOKIE_CHECK inline qvsf RTM_SIMD_CALL qvs_inverse_no_scale(qvsf_arg0 input) RTM_NO_EXCEPT
+	{
+		const quatf inv_rotation = quat_conjugate(input.rotation);
+		const vector4f inv_translation = vector_neg(quat_mul_vector3(input.translation_scale, inv_rotation));
+		const vector4f inv_translation_scale = vector_mix<mix4::x, mix4::y, mix4::z, mix4::d>(inv_translation, input.translation_scale);
+
+		return qvsf{ inv_rotation, inv_translation_scale };
+	}
+
+	//////////////////////////////////////////////////////////////////////////
+	// Returns a QVS transforms with the rotation part normalized.
+	//////////////////////////////////////////////////////////////////////////
+	RTM_DISABLE_SECURITY_COOKIE_CHECK RTM_FORCE_INLINE qvsf RTM_SIMD_CALL qvs_normalize(qvsf_arg0 input) RTM_NO_EXCEPT
+	{
+		const quatf rotation = quat_normalize(input.rotation);
+		return qvsf{ rotation, input.translation_scale };
+	}
+
+	//////////////////////////////////////////////////////////////////////////
+	// Per component linear interpolation of the two inputs at the specified alpha.
+	// The formula used is: ((1.0 - alpha) * start) + (alpha * end).
+	// Interpolation is stable and will return 'start' when alpha is 0.0 and 'end' when it is 1.0.
+	// This is the same instruction count when FMA is present but it might be slightly slower
+	// due to the extra multiplication compared to: start + (alpha * (end - start)).
+	//////////////////////////////////////////////////////////////////////////
+	RTM_DISABLE_SECURITY_COOKIE_CHECK RTM_FORCE_INLINE qvsf RTM_SIMD_CALL qvs_lerp(qvsf_arg0 start, qvsf_arg1 end, float alpha) RTM_NO_EXCEPT
+	{
+		const quatf rotation = quat_lerp(start.rotation, end.rotation, alpha);
+		const vector4f translation_scale = vector_lerp(start.translation_scale, end.translation_scale, alpha);
+		return qvsf{ rotation, translation_scale };
+	}
+
+#if defined(RTM_SSE2_INTRINSICS)
+	//////////////////////////////////////////////////////////////////////////
+	// Per component linear interpolation of the two inputs at the specified alpha.
+	// The formula used is: ((1.0 - alpha) * start) + (alpha * end).
+	// Interpolation is stable and will return 'start' when alpha is 0.0 and 'end' when it is 1.0.
+	// This is the same instruction count when FMA is present but it might be slightly slower
+	// due to the extra multiplication compared to: start + (alpha * (end - start)).
+	//////////////////////////////////////////////////////////////////////////
+	RTM_DISABLE_SECURITY_COOKIE_CHECK RTM_FORCE_INLINE qvsf RTM_SIMD_CALL qvs_lerp(qvsf_arg0 start, qvsf_arg1 end, scalarf_arg2 alpha) RTM_NO_EXCEPT
+	{
+		const quatf rotation = quat_lerp(start.rotation, end.rotation, alpha);
+		const vector4f translation_scale = vector_lerp(start.translation_scale, end.translation_scale, alpha);
+		return qvsf{ rotation, translation_scale };
+	}
+#endif
+
+	//////////////////////////////////////////////////////////////////////////
+	// Per component linear interpolation of the two inputs at the specified alpha.
+	// The formula used is: ((1.0 - alpha) * start) + (alpha * end).
+	// Interpolation is stable and will return 'start' when alpha is 0.0 and 'end' when it is 1.0.
+	// This is the same instruction count when FMA is present but it might be slightly slower
+	// due to the extra multiplication compared to: start + (alpha * (end - start)).
+	// The resulting QVV transform will have the start scale.
+	//////////////////////////////////////////////////////////////////////////
+	RTM_DISABLE_SECURITY_COOKIE_CHECK RTM_FORCE_INLINE qvsf RTM_SIMD_CALL qvs_lerp_no_scale(qvsf_arg0 start, qvsf_arg1 end, float alpha) RTM_NO_EXCEPT
+	{
+		const quatf rotation = quat_lerp(start.rotation, end.rotation, alpha);
+		const vector4f translation_scale_lerp = vector_lerp(start.translation_scale, end.translation_scale, alpha);
+		const vector4f translation_scale = vector_mix<mix4::x, mix4::y, mix4::z, mix4::d>(translation_scale_lerp, start.translation_scale);
+		return qvsf{ rotation, translation_scale };
+	}
+
+#if defined(RTM_SSE2_INTRINSICS)
+	//////////////////////////////////////////////////////////////////////////
+	// Per component linear interpolation of the two inputs at the specified alpha.
+	// The formula used is: ((1.0 - alpha) * start) + (alpha * end).
+	// Interpolation is stable and will return 'start' when alpha is 0.0 and 'end' when it is 1.0.
+	// This is the same instruction count when FMA is present but it might be slightly slower
+	// due to the extra multiplication compared to: start + (alpha * (end - start)).
+	// The resulting QVV transform will have the start scale.
+	//////////////////////////////////////////////////////////////////////////
+	RTM_DISABLE_SECURITY_COOKIE_CHECK RTM_FORCE_INLINE qvsf RTM_SIMD_CALL qvs_lerp_no_scale(qvsf_arg0 start, qvsf_arg1 end, scalarf_arg2 alpha) RTM_NO_EXCEPT
+	{
+		const quatf rotation = quat_lerp(start.rotation, end.rotation, alpha);
+		const vector4f translation_scale_lerp = vector_lerp(start.translation_scale, end.translation_scale, alpha);
+		const vector4f translation_scale = vector_mix<mix4::x, mix4::y, mix4::z, mix4::d>(translation_scale_lerp, start.translation_scale);
+		return qvsf{ rotation, translation_scale };
+	}
+#endif
+
+	//////////////////////////////////////////////////////////////////////////
+	// Per component spherical interpolation of the two inputs at the specified alpha.
+	// See quat_slerp(..)
+	//////////////////////////////////////////////////////////////////////////
+	RTM_DISABLE_SECURITY_COOKIE_CHECK RTM_FORCE_INLINE qvsf RTM_SIMD_CALL qvs_slerp(qvsf_arg0 start, qvsf_arg1 end, float alpha) RTM_NO_EXCEPT
+	{
+		const quatf rotation = quat_slerp(start.rotation, end.rotation, alpha);
+		const vector4f translation_scale = vector_lerp(start.translation_scale, end.translation_scale, alpha);
+		return qvsf{ rotation, translation_scale };
+	}
+
+#if defined(RTM_SSE2_INTRINSICS)
+	//////////////////////////////////////////////////////////////////////////
+	// Per component spherical interpolation of the two inputs at the specified alpha.
+	// See quat_slerp(..)
+	//////////////////////////////////////////////////////////////////////////
+	RTM_DISABLE_SECURITY_COOKIE_CHECK RTM_FORCE_INLINE qvsf RTM_SIMD_CALL qvs_slerp(qvsf_arg0 start, qvsf_arg1 end, scalarf_arg2 alpha) RTM_NO_EXCEPT
+	{
+		const quatf rotation = quat_slerp(start.rotation, end.rotation, alpha);
+		const vector4f translation_scale = vector_lerp(start.translation_scale, end.translation_scale, alpha);
+		return qvsf{ rotation, translation_scale };
+	}
+#endif
+
+	//////////////////////////////////////////////////////////////////////////
+	// Per component spherical interpolation of the two inputs at the specified alpha.
+	// See quat_slerp(..)
+	//////////////////////////////////////////////////////////////////////////
+	RTM_DISABLE_SECURITY_COOKIE_CHECK RTM_FORCE_INLINE qvsf RTM_SIMD_CALL qvs_slerp_no_scale(qvsf_arg0 start, qvsf_arg1 end, float alpha) RTM_NO_EXCEPT
+	{
+		const quatf rotation = quat_slerp(start.rotation, end.rotation, alpha);
+		const vector4f translation_scale_lerp = vector_lerp(start.translation_scale, end.translation_scale, alpha);
+		const vector4f translation_scale = vector_mix<mix4::x, mix4::y, mix4::z, mix4::d>(translation_scale_lerp, start.translation_scale);
+		return qvsf{ rotation, translation_scale };
+	}
+
+#if defined(RTM_SSE2_INTRINSICS)
+	//////////////////////////////////////////////////////////////////////////
+	// Per component spherical interpolation of the two inputs at the specified alpha.
+	// See quat_slerp(..)
+	//////////////////////////////////////////////////////////////////////////
+	RTM_DISABLE_SECURITY_COOKIE_CHECK RTM_FORCE_INLINE qvsf RTM_SIMD_CALL qvv_slerp_no_scale(qvvf_arg0 start, qvvf_arg1 end, scalarf_arg2 alpha) RTM_NO_EXCEPT
+	{
+		const quatf rotation = quat_slerp(start.rotation, end.rotation, alpha);
+		const vector4f translation_scale_lerp = vector_lerp(start.translation_scale, end.translation_scale, alpha);
+		const vector4f translation_scale = vector_mix<mix4::x, mix4::y, mix4::z, mix4::d>(translation_scale_lerp, start.translation_scale);
+		return qvsf{ rotation, translation_scale };
+	}
+#endif
+
+	//////////////////////////////////////////////////////////////////////////
+	// Returns true if the input QVS does not contain any NaN or Inf, otherwise false.
+	//////////////////////////////////////////////////////////////////////////
+	RTM_DISABLE_SECURITY_COOKIE_CHECK RTM_FORCE_INLINE bool RTM_SIMD_CALL qvs_is_finite(qvsf_arg0 input) RTM_NO_EXCEPT
+	{
+		return quat_is_finite(input.rotation) && vector_is_finite(input.translation_scale);
+	}
+
+	RTM_IMPL_VERSION_NAMESPACE_END
+}
+
+RTM_IMPL_FILE_PRAGMA_POP

--- a/includes/rtm/qvsf.h
+++ b/includes/rtm/qvsf.h
@@ -259,7 +259,7 @@ namespace rtm
 	// Per component spherical interpolation of the two inputs at the specified alpha.
 	// See quat_slerp(..)
 	//////////////////////////////////////////////////////////////////////////
-	RTM_DISABLE_SECURITY_COOKIE_CHECK RTM_FORCE_INLINE qvsf RTM_SIMD_CALL qvv_slerp_no_scale(qvvf_arg0 start, qvvf_arg1 end, scalarf_arg2 alpha) RTM_NO_EXCEPT
+	RTM_DISABLE_SECURITY_COOKIE_CHECK RTM_FORCE_INLINE qvsf RTM_SIMD_CALL qvv_slerp_no_scale(qvsf_arg0 start, qvsf_arg1 end, scalarf_arg2 alpha) RTM_NO_EXCEPT
 	{
 		const quatf rotation = quat_slerp(start.rotation, end.rotation, alpha);
 		const vector4f translation_scale_lerp = vector_lerp(start.translation_scale, end.translation_scale, alpha);

--- a/includes/rtm/qvsf.h
+++ b/includes/rtm/qvsf.h
@@ -259,7 +259,7 @@ namespace rtm
 	// Per component spherical interpolation of the two inputs at the specified alpha.
 	// See quat_slerp(..)
 	//////////////////////////////////////////////////////////////////////////
-	RTM_DISABLE_SECURITY_COOKIE_CHECK RTM_FORCE_INLINE qvsf RTM_SIMD_CALL qvv_slerp_no_scale(qvsf_arg0 start, qvsf_arg1 end, scalarf_arg2 alpha) RTM_NO_EXCEPT
+	RTM_DISABLE_SECURITY_COOKIE_CHECK RTM_FORCE_INLINE qvsf RTM_SIMD_CALL qvs_slerp_no_scale(qvsf_arg0 start, qvsf_arg1 end, scalarf_arg2 alpha) RTM_NO_EXCEPT
 	{
 		const quatf rotation = quat_slerp(start.rotation, end.rotation, alpha);
 		const vector4f translation_scale_lerp = vector_lerp(start.translation_scale, end.translation_scale, alpha);

--- a/includes/rtm/type_traits.h
+++ b/includes/rtm/type_traits.h
@@ -47,6 +47,7 @@ namespace rtm
 		using quat = quatf;
 
 		using qv = qvf;
+		using qvs = qvsf;
 		using qvv = qvvf;
 
 		using matrix3x3 = matrix3x3f;
@@ -71,6 +72,7 @@ namespace rtm
 		using quat = quatd;
 
 		using qv = qvd;
+		using qvs = qvsd;
 		using qvv = qvvd;
 
 		using matrix3x3 = matrix3x3d;

--- a/includes/rtm/types.h
+++ b/includes/rtm/types.h
@@ -359,6 +359,26 @@ namespace rtm
 	};
 
 	//////////////////////////////////////////////////////////////////////////
+	// A QVS transform represents a 3D rotation (quaternion), a 3D translation (vector),
+	// and a single scalar scale value.
+	//////////////////////////////////////////////////////////////////////////
+	struct qvsf
+	{
+		quatf		rotation;
+		vector4f	translation_scale;	// [xyz] for translation, [w] for scale
+	};
+
+	//////////////////////////////////////////////////////////////////////////
+	// A QVS transform represents a 3D rotation (quaternion), a 3D translation (vector),
+	// and a single scalar scale value.
+	//////////////////////////////////////////////////////////////////////////
+	struct qvsd
+	{
+		quatd		rotation;
+		vector4d	translation_scale;	// [xyz] for translation, [w] for scale
+	};
+
+	//////////////////////////////////////////////////////////////////////////
 	// A QVV transform represents a 3D rotation (quaternion), 3D translation (vector), and 3D scale (vector).
 	// It properly handles positive scaling but negative scaling is a bit more problematic.
 	// A best effort is made by converting the quaternion to a matrix during those operations.

--- a/includes/rtm/types.h
+++ b/includes/rtm/types.h
@@ -346,7 +346,7 @@ namespace rtm
 	struct qvf
 	{
 		quatf		rotation;
-		vector4f	translation;
+		vector4f	translation;	// [w] is undefined
 	};
 
 	//////////////////////////////////////////////////////////////////////////
@@ -355,7 +355,7 @@ namespace rtm
 	struct qvd
 	{
 		quatd		rotation;
-		vector4d	translation;
+		vector4d	translation;	// [w] is undefined
 	};
 
 	//////////////////////////////////////////////////////////////////////////
@@ -367,8 +367,8 @@ namespace rtm
 	struct qvvf
 	{
 		quatf		rotation;
-		vector4f	translation;
-		vector4f	scale;
+		vector4f	translation;	// [w] is undefined
+		vector4f	scale;			// [w] is undefined
 	};
 
 	//////////////////////////////////////////////////////////////////////////
@@ -380,8 +380,8 @@ namespace rtm
 	struct qvvd
 	{
 		quatd		rotation;
-		vector4d	translation;
-		vector4d	scale;
+		vector4d	translation;	// [w] is undefined
+		vector4d	scale;			// [w] is undefined
 	};
 
 	//////////////////////////////////////////////////////////////////////////

--- a/tests/sources/test_matrix3x3_impl.h
+++ b/tests/sources/test_matrix3x3_impl.h
@@ -212,6 +212,18 @@ static void test_matrix3x3_misc(const FloatType threshold)
 	{
 		QuatType rotation_around_z = quat_from_euler(scalar_deg_to_rad(FloatType(0.0)), scalar_deg_to_rad(FloatType(90.0)), scalar_deg_to_rad(FloatType(0.0)));
 		Vector4Type translation = vector_set(FloatType(1.0), FloatType(2.0), FloatType(3.0));
+		FloatType scale = FloatType(4.0);
+		Matrix3x4Type mtx0_3x4 = matrix_from_qvs(rotation_around_z, translation, scale);
+		Matrix3x3Type mtx0 = matrix_cast(mtx0_3x4);
+		Matrix3x3Type mtx0_no_scale = matrix_remove_scale(mtx0);
+		CHECK(vector_all_near_equal3(vector_set(FloatType(0.0), FloatType(1.0), FloatType(0.0)), mtx0_no_scale.x_axis, threshold));
+		CHECK(vector_all_near_equal3(vector_set(FloatType(-1.0), FloatType(0.0), FloatType(0.0)), mtx0_no_scale.y_axis, threshold));
+		CHECK(vector_all_near_equal3(vector_set(FloatType(0.0), FloatType(0.0), FloatType(1.0)), mtx0_no_scale.z_axis, threshold));
+	}
+
+	{
+		QuatType rotation_around_z = quat_from_euler(scalar_deg_to_rad(FloatType(0.0)), scalar_deg_to_rad(FloatType(90.0)), scalar_deg_to_rad(FloatType(0.0)));
+		Vector4Type translation = vector_set(FloatType(1.0), FloatType(2.0), FloatType(3.0));
 		Vector4Type scale = vector_set(FloatType(4.0), FloatType(5.0), FloatType(6.0));
 		Matrix3x4Type mtx0_3x4 = matrix_from_qvv(rotation_around_z, translation, scale);
 		Matrix3x3Type mtx0 = matrix_cast(mtx0_3x4);

--- a/tests/sources/test_matrix3x4.cpp
+++ b/tests/sources/test_matrix3x4.cpp
@@ -30,6 +30,8 @@
 #include <rtm/matrix3x4d.h>
 #include <rtm/qvf.h>
 #include <rtm/qvd.h>
+#include <rtm/qvsf.h>
+#include <rtm/qvsd.h>
 #include <rtm/qvvf.h>
 #include <rtm/qvvd.h>
 
@@ -41,6 +43,7 @@ static void test_affine_matrix_setters(const FloatType threshold)
 	using QuatType = typename float_traits<FloatType>::quat;
 	using Vector4Type = typename float_traits<FloatType>::vector4;
 	using QVType = typename float_traits<FloatType>::qv;
+	using QVSType = typename float_traits<FloatType>::qvs;
 	using QVVType = typename float_traits<FloatType>::qvv;
 	using Matrix3x3Type = typename float_traits<FloatType>::matrix3x3;
 	using Matrix3x4Type = typename float_traits<FloatType>::matrix3x4;
@@ -73,6 +76,23 @@ static void test_affine_matrix_setters(const FloatType threshold)
 		CHECK(vector_all_near_equal3(vector_set(FloatType(0.0), FloatType(1.0), FloatType(0.0), FloatType(0.0)), mtx.x_axis, threshold));
 		CHECK(vector_all_near_equal3(vector_set(FloatType(-1.0), FloatType(0.0), FloatType(0.0), FloatType(0.0)), mtx.y_axis, threshold));
 		CHECK(vector_all_near_equal3(vector_set(FloatType(0.0), FloatType(0.0), FloatType(1.0), FloatType(0.0)), mtx.z_axis, threshold));
+		CHECK(vector_all_near_equal3(vector_set(FloatType(1.0), FloatType(2.0), FloatType(3.0), FloatType(1.0)), mtx.w_axis, threshold));
+	}
+
+	{
+		QuatType rotation_around_z = quat_from_euler(scalar_deg_to_rad(FloatType(0.0)), scalar_deg_to_rad(FloatType(90.0)), scalar_deg_to_rad(FloatType(0.0)));
+		Vector4Type translation = vector_set(FloatType(1.0), FloatType(2.0), FloatType(3.0));
+		Matrix3x4Type mtx = matrix_from_qvs(rotation_around_z, translation, FloatType(1.0));
+		CHECK(vector_all_near_equal3(vector_set(FloatType(0.0), FloatType(1.0), FloatType(0.0), FloatType(0.0)), mtx.x_axis, threshold));
+		CHECK(vector_all_near_equal3(vector_set(FloatType(-1.0), FloatType(0.0), FloatType(0.0), FloatType(0.0)), mtx.y_axis, threshold));
+		CHECK(vector_all_near_equal3(vector_set(FloatType(0.0), FloatType(0.0), FloatType(1.0), FloatType(0.0)), mtx.z_axis, threshold));
+		CHECK(vector_all_near_equal3(vector_set(FloatType(1.0), FloatType(2.0), FloatType(3.0), FloatType(1.0)), mtx.w_axis, threshold));
+
+		FloatType scale = FloatType(4.0);
+		mtx = matrix_from_qvs(rotation_around_z, translation, scale);
+		CHECK(vector_all_near_equal3(vector_set(FloatType(0.0), FloatType(4.0), FloatType(0.0), FloatType(0.0)), mtx.x_axis, threshold));
+		CHECK(vector_all_near_equal3(vector_set(FloatType(-4.0), FloatType(0.0), FloatType(0.0), FloatType(0.0)), mtx.y_axis, threshold));
+		CHECK(vector_all_near_equal3(vector_set(FloatType(0.0), FloatType(0.0), FloatType(4.0), FloatType(0.0)), mtx.z_axis, threshold));
 		CHECK(vector_all_near_equal3(vector_set(FloatType(1.0), FloatType(2.0), FloatType(3.0), FloatType(1.0)), mtx.w_axis, threshold));
 	}
 
@@ -145,6 +165,18 @@ static void test_affine_matrix_setters(const FloatType threshold)
 		CHECK(vector_all_near_equal3(vector_set(FloatType(0.0), FloatType(1.0), FloatType(0.0), FloatType(0.0)), mtx.x_axis, threshold));
 		CHECK(vector_all_near_equal3(vector_set(FloatType(-1.0), FloatType(0.0), FloatType(0.0), FloatType(0.0)), mtx.y_axis, threshold));
 		CHECK(vector_all_near_equal3(vector_set(FloatType(0.0), FloatType(0.0), FloatType(1.0), FloatType(0.0)), mtx.z_axis, threshold));
+		CHECK(vector_all_near_equal3(vector_set(FloatType(1.0), FloatType(2.0), FloatType(3.0), FloatType(1.0)), mtx.w_axis, threshold));
+	}
+
+	{
+		QuatType rotation_around_z = quat_from_euler(scalar_deg_to_rad(FloatType(0.0)), scalar_deg_to_rad(FloatType(90.0)), scalar_deg_to_rad(FloatType(0.0)));
+		Vector4Type translation = vector_set(FloatType(1.0), FloatType(2.0), FloatType(3.0));
+		FloatType scale = FloatType(4.0);
+		QVSType transform = qvs_set(rotation_around_z, translation, scale);
+		Matrix3x4Type mtx = matrix_from_qvs(transform);
+		CHECK(vector_all_near_equal3(vector_set(FloatType(0.0), FloatType(4.0), FloatType(0.0), FloatType(0.0)), mtx.x_axis, threshold));
+		CHECK(vector_all_near_equal3(vector_set(FloatType(-4.0), FloatType(0.0), FloatType(0.0), FloatType(0.0)), mtx.y_axis, threshold));
+		CHECK(vector_all_near_equal3(vector_set(FloatType(0.0), FloatType(0.0), FloatType(4.0), FloatType(0.0)), mtx.z_axis, threshold));
 		CHECK(vector_all_near_equal3(vector_set(FloatType(1.0), FloatType(2.0), FloatType(3.0), FloatType(1.0)), mtx.w_axis, threshold));
 	}
 

--- a/tests/sources/test_qvs.cpp
+++ b/tests/sources/test_qvs.cpp
@@ -1,0 +1,289 @@
+////////////////////////////////////////////////////////////////////////////////
+// The MIT License (MIT)
+//
+// Copyright (c) 2023 Nicholas Frechette & Realtime Math contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+////////////////////////////////////////////////////////////////////////////////
+
+#include <catch2/catch.hpp>
+
+#include <rtm/qvsf.h>
+#include <rtm/qvsd.h>
+#include <rtm/type_traits.h>
+
+using namespace rtm;
+
+template<typename TransformType, typename FloatType>
+static void test_qvs_impl(const TransformType& identity, const FloatType threshold)
+{
+	using QuatType = typename float_traits<FloatType>::quat;
+	using Vector4Type = typename float_traits<FloatType>::vector4;
+	using ScalarType = typename float_traits<FloatType>::scalar;
+
+	{
+		Vector4Type zero = vector_set(FloatType(0.0));
+		FloatType one = FloatType(1.0);
+		QuatType q_identity = quat_set(FloatType(0.0), FloatType(0.0), FloatType(0.0), FloatType(1.0));
+		TransformType tmp = qvs_set(q_identity, zero, one);
+		CHECK(quat_near_equal(identity.rotation, tmp.rotation, threshold));
+		CHECK(vector_all_near_equal(identity.translation_scale, tmp.translation_scale, threshold));
+		CHECK(quat_near_equal(q_identity, tmp.rotation, threshold));
+		CHECK(vector_all_near_equal3(zero, qvs_get_translation(tmp), threshold));
+		CHECK(scalar_near_equal(one, qvs_get_scale(tmp), threshold));
+	}
+
+	{
+		Vector4Type x_axis = vector_set(FloatType(1.0), FloatType(0.0), FloatType(0.0));
+		Vector4Type y_axis = vector_set(FloatType(0.0), FloatType(1.0), FloatType(0.0));
+		FloatType test_scale = FloatType(1.2);
+
+		QuatType rotation_around_z = quat_from_euler(scalar_deg_to_rad(FloatType(0.0)), scalar_deg_to_rad(FloatType(90.0)), scalar_deg_to_rad(FloatType(0.0)));
+		TransformType transform_a = qvs_set(rotation_around_z, x_axis, test_scale);
+		Vector4Type result = qvs_mul_point3(x_axis, transform_a);
+		CHECK(vector_all_near_equal3(result, vector_set(FloatType(1.0), FloatType(1.2), FloatType(0.0)), threshold));
+		result = qvs_mul_point3(y_axis, transform_a);
+		CHECK(vector_all_near_equal3(result, vector_set(FloatType(-0.2), FloatType(0.0), FloatType(0.0)), threshold));
+
+		QuatType rotation_around_x = quat_from_euler(scalar_deg_to_rad(FloatType(0.0)), scalar_deg_to_rad(FloatType(0.0)), scalar_deg_to_rad(FloatType(90.0)));
+		TransformType transform_b = qvs_set(rotation_around_x, y_axis, test_scale);
+		result = qvs_mul_point3(x_axis, transform_b);
+		CHECK(vector_all_near_equal3(result, vector_set(FloatType(1.2), FloatType(1.0), FloatType(0.0)), threshold));
+		result = qvs_mul_point3(y_axis, transform_b);
+		CHECK(vector_all_near_equal3(result, vector_set(FloatType(0.0), FloatType(1.0), FloatType(-1.2)), threshold));
+
+		TransformType transform_ab = qvs_mul(transform_a, transform_b);
+		TransformType transform_ba = qvs_mul(transform_b, transform_a);
+		result = qvs_mul_point3(x_axis, transform_ab);
+		CHECK(vector_all_near_equal3(result, vector_set(FloatType(1.2), FloatType(1.0), FloatType(-1.44)), threshold));
+		CHECK(vector_all_near_equal3(result, qvs_mul_point3(qvs_mul_point3(x_axis, transform_a), transform_b), threshold));
+		result = qvs_mul_point3(y_axis, transform_ab);
+		CHECK(vector_all_near_equal3(result, vector_set(FloatType(-0.24), FloatType(1.0), FloatType(0.0)), threshold));
+		CHECK(vector_all_near_equal3(result, qvs_mul_point3(qvs_mul_point3(y_axis, transform_a), transform_b), threshold));
+		result = qvs_mul_point3(x_axis, transform_ba);
+		CHECK(vector_all_near_equal3(result, vector_set(FloatType(-0.2), FloatType(1.44), FloatType(0.0)), threshold));
+		CHECK(vector_all_near_equal3(result, qvs_mul_point3(qvs_mul_point3(x_axis, transform_b), transform_a), threshold));
+		result = qvs_mul_point3(y_axis, transform_ba);
+		CHECK(vector_all_near_equal3(result, vector_set(FloatType(-0.2), FloatType(0.0), FloatType(-1.44)), threshold));
+		CHECK(vector_all_near_equal3(result, qvs_mul_point3(qvs_mul_point3(y_axis, transform_b), transform_a), threshold));
+	}
+
+	{
+		Vector4Type x_axis = vector_set(FloatType(1.0), FloatType(0.0), FloatType(0.0));
+		Vector4Type y_axis = vector_set(FloatType(0.0), FloatType(1.0), FloatType(0.0));
+
+		QuatType rotation_around_z = quat_from_euler(scalar_deg_to_rad(FloatType(0.0)), scalar_deg_to_rad(FloatType(90.0)), scalar_deg_to_rad(FloatType(0.0)));
+		TransformType transform_a = qvs_set(rotation_around_z, x_axis, FloatType(1.0));
+		Vector4Type result = qvs_mul_point3_no_scale(x_axis, transform_a);
+		CHECK(vector_all_near_equal3(result, vector_set(FloatType(1.0), FloatType(1.0), FloatType(0.0)), threshold));
+		result = qvs_mul_point3_no_scale(y_axis, transform_a);
+		CHECK(vector_all_near_equal3(result, vector_set(FloatType(0.0), FloatType(0.0), FloatType(0.0)), threshold));
+
+		QuatType rotation_around_x = quat_from_euler(scalar_deg_to_rad(FloatType(0.0)), scalar_deg_to_rad(FloatType(0.0)), scalar_deg_to_rad(FloatType(90.0)));
+		TransformType transform_b = qvs_set(rotation_around_x, y_axis, FloatType(1.0));
+		result = qvs_mul_point3_no_scale(x_axis, transform_b);
+		CHECK(vector_all_near_equal3(result, vector_set(FloatType(1.0), FloatType(1.0), FloatType(0.0)), threshold));
+		result = qvs_mul_point3_no_scale(y_axis, transform_b);
+		CHECK(vector_all_near_equal3(result, vector_set(FloatType(0.0), FloatType(1.0), FloatType(-1.0)), threshold));
+
+		TransformType transform_ab = qvs_mul_no_scale(transform_a, transform_b);
+		TransformType transform_ba = qvs_mul_no_scale(transform_b, transform_a);
+		result = qvs_mul_point3_no_scale(x_axis, transform_ab);
+		CHECK(vector_all_near_equal3(result, vector_set(FloatType(1.0), FloatType(1.0), FloatType(-1.0)), threshold));
+		CHECK(vector_all_near_equal3(result, qvs_mul_point3_no_scale(qvs_mul_point3_no_scale(x_axis, transform_a), transform_b), threshold));
+		result = qvs_mul_point3_no_scale(y_axis, transform_ab);
+		CHECK(vector_all_near_equal3(result, vector_set(FloatType(0.0), FloatType(1.0), FloatType(0.0)), threshold));
+		CHECK(vector_all_near_equal3(result, qvs_mul_point3_no_scale(qvs_mul_point3_no_scale(y_axis, transform_a), transform_b), threshold));
+		result = qvs_mul_point3_no_scale(x_axis, transform_ba);
+		CHECK(vector_all_near_equal3(result, vector_set(FloatType(0.0), FloatType(1.0), FloatType(0.0)), threshold));
+		CHECK(vector_all_near_equal3(result, qvs_mul_point3_no_scale(qvs_mul_point3_no_scale(x_axis, transform_b), transform_a), threshold));
+		result = qvs_mul_point3_no_scale(y_axis, transform_ba);
+		CHECK(vector_all_near_equal3(result, vector_set(FloatType(0.0), FloatType(0.0), FloatType(-1.0)), threshold));
+		CHECK(vector_all_near_equal3(result, qvs_mul_point3_no_scale(qvs_mul_point3_no_scale(y_axis, transform_b), transform_a), threshold));
+	}
+
+	{
+		Vector4Type x_axis = vector_set(FloatType(1.0), FloatType(0.0), FloatType(0.0));
+		FloatType test_scale1 = FloatType(1.2);
+		FloatType test_scale2 = FloatType(-1.2);
+
+		QuatType rotation_around_z = quat_from_euler(scalar_deg_to_rad(FloatType(0.0)), scalar_deg_to_rad(FloatType(90.0)), scalar_deg_to_rad(FloatType(0.0)));
+		TransformType transform_a = qvs_set(rotation_around_z, x_axis, test_scale1);
+		TransformType transform_b = qvs_inverse(transform_a);
+		TransformType transform_ab = qvs_mul(transform_a, transform_b);
+		CHECK(quat_near_equal(identity.rotation, transform_ab.rotation, threshold));
+		CHECK(vector_all_near_equal3(qvs_get_translation(identity), qvs_get_translation(transform_ab), threshold));
+		CHECK(scalar_near_equal(qvs_get_scale(identity), qvs_get_scale(transform_ab), threshold));
+
+		transform_a = qvs_set(rotation_around_z, x_axis, test_scale2);
+		transform_b = qvs_inverse(transform_a);
+		transform_ab = qvs_mul(transform_a, transform_b);
+		CHECK(quat_near_equal(identity.rotation, transform_ab.rotation, threshold));
+		CHECK(vector_all_near_equal3(qvs_get_translation(identity), qvs_get_translation(transform_ab), threshold));
+		CHECK(scalar_near_equal(qvs_get_scale(identity), qvs_get_scale(transform_ab), threshold));
+	}
+
+	{
+		Vector4Type x_axis = vector_set(FloatType(1.0), FloatType(0.0), FloatType(0.0));
+
+		QuatType rotation_around_z = quat_from_euler(scalar_deg_to_rad(FloatType(0.0)), scalar_deg_to_rad(FloatType(90.0)), scalar_deg_to_rad(FloatType(0.0)));
+		TransformType transform_a = qvs_set(rotation_around_z, x_axis, FloatType(1.0));
+		TransformType transform_b = qvs_inverse_no_scale(transform_a);
+		TransformType transform_ab = qvs_mul_no_scale(transform_a, transform_b);
+		CHECK(quat_near_equal(identity.rotation, transform_ab.rotation, threshold));
+		CHECK(vector_all_near_equal3(qvs_get_translation(identity), qvs_get_translation(transform_ab), threshold));
+		CHECK(scalar_near_equal(qvs_get_scale(identity), qvs_get_scale(transform_ab), threshold));
+	}
+
+	{
+		Vector4Type x_axis = vector_set(FloatType(1.0), FloatType(0.0), FloatType(0.0));
+		QuatType rotation_around_z = quat_from_euler(scalar_deg_to_rad(FloatType(0.0)), scalar_deg_to_rad(FloatType(90.0)), scalar_deg_to_rad(FloatType(0.0)));
+		TransformType transform_a = qvs_set(rotation_around_z, x_axis, FloatType(1.0));
+		CHECK(quat_is_normalized(qvs_normalize(transform_a).rotation, threshold));
+
+		QuatType quat = quat_set(FloatType(-0.001138), FloatType(0.91623), FloatType(-1.624598), FloatType(0.715671));
+		TransformType transform_b = qvs_set(quat, x_axis, FloatType(1.0));
+		CHECK(!quat_is_normalized(transform_b.rotation, threshold));
+		CHECK(quat_is_normalized(qvs_normalize(transform_b).rotation, threshold));
+	}
+
+	{
+		FloatType alpha = FloatType(0.33);
+		ScalarType alpha_s = scalar_set(alpha);
+		QuatType quat0 = quat_normalize(quat_from_euler(scalar_deg_to_rad(FloatType(30.0)), scalar_deg_to_rad(FloatType(-45.0)), scalar_deg_to_rad(FloatType(90.0))));
+		QuatType quat1 = quat_normalize(quat_from_euler(scalar_deg_to_rad(FloatType(45.0)), scalar_deg_to_rad(FloatType(60.0)), scalar_deg_to_rad(FloatType(120.0))));
+
+		QuatType quat_ref_lerp = quat_lerp(quat0, quat1, alpha);
+		QuatType quat_ref_lerp_s = quat_lerp(quat0, quat1, alpha_s);
+		QuatType quat_ref_slerp = quat_slerp(quat0, quat1, alpha);
+		QuatType quat_ref_slerp_s = quat_slerp(quat0, quat1, alpha_s);
+
+		Vector4Type trans0 = vector_set(FloatType(-0.001138), FloatType(0.91623), FloatType(-1.624598));
+		Vector4Type trans1 = vector_set(FloatType(-0.001138), FloatType(0.91623), FloatType(-1.624598));
+
+		Vector4Type trans_ref = vector_lerp(trans0, trans1, alpha);
+		Vector4Type trans_ref_s = vector_lerp(trans0, trans1, alpha_s);
+
+		FloatType scale0 = FloatType(-1.915);
+		FloatType scale1 = FloatType(-0.2113);
+
+		FloatType scale_ref = scalar_lerp(scale0, scale1, alpha);
+		ScalarType scale_ref_s = scalar_lerp(scalar_set(scale0), scalar_set(scale1), alpha_s);
+
+		TransformType transform0 = qvs_set(quat0, trans0, scale0);
+		TransformType transform1 = qvs_set(quat1, trans1, scale1);
+
+		TransformType transform_ref_lerp = qvs_set(quat_ref_lerp, trans_ref, scale_ref);
+		TransformType transform_ref_slerp = qvs_set(quat_ref_slerp, trans_ref, scale_ref);
+
+		TransformType transform_ref_lerp_s = qvs_set(quat_ref_lerp_s, trans_ref_s, scale_ref_s);
+		TransformType transform_ref_slerp_s = qvs_set(quat_ref_slerp_s, trans_ref_s, scale_ref_s);
+
+		TransformType transform_lerp = qvs_lerp(transform0, transform1, alpha);
+		TransformType transform_lerp_s = qvs_lerp(transform0, transform1, alpha_s);
+
+		TransformType transform_slerp = qvs_slerp(transform0, transform1, alpha);
+		TransformType transform_slerp_s = qvs_slerp(transform0, transform1, alpha_s);
+
+		TransformType transform_lerp_no_scale = qvs_lerp_no_scale(transform0, transform1, alpha);
+		TransformType transform_lerp_no_scale_s = qvs_lerp_no_scale(transform0, transform1, alpha_s);
+
+		TransformType transform_slerp_no_scale = qvs_slerp_no_scale(transform0, transform1, alpha);
+		TransformType transform_slerp_no_scale_s = qvs_slerp_no_scale(transform0, transform1, alpha_s);
+
+		CHECK(quat_near_equal(transform_lerp.rotation, transform_ref_lerp.rotation, threshold));
+		CHECK(quat_near_equal(transform_lerp_s.rotation, transform_ref_lerp_s.rotation, threshold));
+		CHECK(vector_all_near_equal3(qvs_get_translation(transform_lerp), qvs_get_translation(transform_ref_lerp), threshold));
+		CHECK(vector_all_near_equal3(qvs_get_translation(transform_lerp_s), qvs_get_translation(transform_ref_lerp_s), threshold));
+		CHECK(scalar_near_equal(qvs_get_scale(transform_lerp), qvs_get_scale(transform_ref_lerp), threshold));
+		CHECK(scalar_near_equal(qvs_get_scale(transform_lerp_s), qvs_get_scale(transform_ref_lerp_s), threshold));
+
+		CHECK(quat_near_equal(transform_slerp.rotation, transform_ref_slerp.rotation, threshold));
+		CHECK(quat_near_equal(transform_slerp_s.rotation, transform_ref_slerp_s.rotation, threshold));
+		CHECK(vector_all_near_equal3(qvs_get_translation(transform_slerp), qvs_get_translation(transform_ref_slerp), threshold));
+		CHECK(vector_all_near_equal3(qvs_get_translation(transform_slerp_s), qvs_get_translation(transform_ref_slerp_s), threshold));
+		CHECK(scalar_near_equal(qvs_get_scale(transform_slerp), qvs_get_scale(transform_ref_slerp), threshold));
+		CHECK(scalar_near_equal(qvs_get_scale(transform_slerp_s), qvs_get_scale(transform_ref_slerp_s), threshold));
+
+		CHECK(quat_near_equal(transform_lerp_no_scale.rotation, transform_ref_lerp.rotation, threshold));
+		CHECK(quat_near_equal(transform_lerp_no_scale_s.rotation, transform_ref_lerp_s.rotation, threshold));
+		CHECK(vector_all_near_equal3(qvs_get_translation(transform_lerp_no_scale), qvs_get_translation(transform_ref_lerp), threshold));
+		CHECK(vector_all_near_equal3(qvs_get_translation(transform_lerp_no_scale_s), qvs_get_translation(transform_ref_lerp_s), threshold));
+		CHECK(scalar_near_equal(qvs_get_scale(transform_lerp_no_scale), qvs_get_scale(transform0), threshold));
+		CHECK(scalar_near_equal(qvs_get_scale(transform_lerp_no_scale_s), qvs_get_scale(transform0), threshold));
+
+		CHECK(quat_near_equal(transform_slerp_no_scale.rotation, transform_ref_slerp.rotation, threshold));
+		CHECK(quat_near_equal(transform_slerp_no_scale_s.rotation, transform_ref_slerp_s.rotation, threshold));
+		CHECK(vector_all_near_equal3(qvs_get_translation(transform_slerp_no_scale), qvs_get_translation(transform_ref_slerp), threshold));
+		CHECK(vector_all_near_equal3(qvs_get_translation(transform_slerp_no_scale_s), qvs_get_translation(transform_ref_slerp_s), threshold));
+		CHECK(scalar_near_equal(qvs_get_scale(transform_slerp_no_scale), qvs_get_scale(transform0), threshold));
+		CHECK(scalar_near_equal(qvs_get_scale(transform_slerp_no_scale_s), qvs_get_scale(transform0), threshold));
+	}
+
+	{
+		const FloatType inf = std::numeric_limits<FloatType>::infinity();
+		const FloatType nan = std::numeric_limits<FloatType>::quiet_NaN();
+
+		const QuatType quat0 = quat_normalize(quat_from_euler(scalar_deg_to_rad(FloatType(30.0)), scalar_deg_to_rad(FloatType(-45.0)), scalar_deg_to_rad(FloatType(90.0))));
+		const QuatType quat_inf = quat_set(inf, inf, inf, inf);
+		const QuatType quat_nan = quat_set(nan, nan, nan, nan);
+
+		const Vector4Type trans0 = vector_set(FloatType(-0.001138), FloatType(0.91623), FloatType(-1.624598));
+		const FloatType scale0 = FloatType(-1.915);
+		const Vector4Type vec_inf = vector_set(inf, inf, inf, inf);
+		const Vector4Type vec_nan = vector_set(nan, nan, nan, nan);
+
+		CHECK(qvs_is_finite(identity) == true);
+		CHECK(qvs_is_finite(qvs_set(quat0, trans0, scale0)) == true);
+		CHECK(qvs_is_finite(qvs_set(quat_inf, trans0, scale0)) == false);
+		CHECK(qvs_is_finite(qvs_set(quat_nan, trans0, scale0)) == false);
+		CHECK(qvs_is_finite(qvs_set(quat0, vec_inf, scale0)) == false);
+		CHECK(qvs_is_finite(qvs_set(quat0, vec_nan, scale0)) == false);
+		CHECK(qvs_is_finite(qvs_set(quat0, trans0, inf)) == false);
+		CHECK(qvs_is_finite(qvs_set(quat0, trans0, nan)) == false);
+		CHECK(qvs_is_finite(qvs_set(quat_inf, vec_inf, inf)) == false);
+		CHECK(qvs_is_finite(qvs_set(quat_nan, vec_nan, nan)) == false);
+	}
+}
+
+TEST_CASE("qvsf math", "[math][qvs]")
+{
+	test_qvs_impl<qvsf, float>(qvs_identity(), 1.0E-4F);
+
+	const quatf src_rotation = quat_set(0.39564531008956383F, 0.044254239301713752F, 0.22768840967675355F, 0.88863059760894492F);
+	const vector4f src_translation = vector_set(-2.65F, 2.996113F, 0.68123521F);
+	const float src_scale = 1.2F;
+	const qvsf src = qvs_set(src_rotation, src_translation, src_scale);
+	const qvsd dst = qvs_cast(src);
+	CHECK(quat_near_equal(src.rotation, quat_cast(dst.rotation), 1.0E-6F));
+	CHECK(vector_all_near_equal(src.translation_scale, vector_cast(dst.translation_scale), 1.0E-6F));
+}
+
+TEST_CASE("qvsd math", "[math][qvs]")
+{
+	test_qvs_impl<qvsd, double>(qvs_identity(), 1.0E-6);
+
+	const quatd src_rotation = quat_set(0.39564531008956383, 0.044254239301713752, 0.22768840967675355, 0.88863059760894492);
+	const vector4d src_translation = vector_set(-2.65, 2.996113, 0.68123521);
+	const double src_scale = 1.2;
+	const qvsd src = qvs_set(src_rotation, src_translation, src_scale);
+	const qvsf dst = qvs_cast(src);
+	CHECK(quat_near_equal(src.rotation, quat_cast(dst.rotation), 1.0E-6));
+	CHECK(vector_all_near_equal(src.translation_scale, vector_cast(dst.translation_scale), 1.0E-6));
+}

--- a/tests/sources/test_qvs.cpp
+++ b/tests/sources/test_qvs.cpp
@@ -155,12 +155,14 @@ static void test_qvs_impl(const TransformType& identity, const FloatType thresho
 		Vector4Type x_axis = vector_set(FloatType(1.0), FloatType(0.0), FloatType(0.0));
 		QuatType rotation_around_z = quat_from_euler(scalar_deg_to_rad(FloatType(0.0)), scalar_deg_to_rad(FloatType(90.0)), scalar_deg_to_rad(FloatType(0.0)));
 		TransformType transform_a = qvs_set(rotation_around_z, x_axis, FloatType(1.0));
-		CHECK(quat_is_normalized(qvs_normalize(transform_a).rotation, threshold));
+		transform_a = qvs_normalize(transform_a);
+		CHECK(quat_is_normalized(transform_a.rotation, threshold));
 
 		QuatType quat = quat_set(FloatType(-0.001138), FloatType(0.91623), FloatType(-1.624598), FloatType(0.715671));
 		TransformType transform_b = qvs_set(quat, x_axis, FloatType(1.0));
 		CHECK(!quat_is_normalized(transform_b.rotation, threshold));
-		CHECK(quat_is_normalized(qvs_normalize(transform_b).rotation, threshold));
+		transform_b = qvs_normalize(transform_b);
+		CHECK(quat_is_normalized(transform_b.rotation, threshold));
 	}
 
 	{


### PR DESCRIPTION
A quat-vector type with uniform scalar scale is common in gamedev as it is fast, compact, and doesn't have the complexity of non-uniform scaling.