### PR TITLE
fix: add missing SSE3 header

### DIFF
--- a/includes/rtm/math.h
+++ b/includes/rtm/math.h
@@ -84,6 +84,7 @@
 
 #if defined(RTM_SSE3_INTRINSICS)
 	#include <pmmintrin.h>
+	#include <tmmintrin.h>
 #endif
 
 #if defined(RTM_SSE4_INTRINSICS)


### PR DESCRIPTION
Can cause compilation failure when SSE3 is enabled without SSE 4.1