### PR TITLE
fix(mask): narrow codegen hack to VS2017 and earlier

### DIFF
--- a/includes/rtm/impl/mask_common.h
+++ b/includes/rtm/impl/mask_common.h
@@ -199,12 +199,12 @@ namespace rtm
 #if defined(RTM_SSE2_INTRINSICS)
 	//////////////////////////////////////////////////////////////////////////
 	// HACK ALERT!
-	// VS2015, VS2017, and VS2019 crash when compiling with _mm_set_epi64x() here.
+	// VS2015 and VS2017 crash when compiling with _mm_set_epi64x() here.
 	// To work around this, we use alternative code. We assume that the high and low words
 	// are identical in the mask, which should be true.
 	// See: https://github.com/nfrechette/rtm/issues/84
 	//////////////////////////////////////////////////////////////////////////
-	#if defined(RTM_COMPILER_MSVC) && defined(RTM_ARCH_X86) && !defined(NDEBUG)
+	#if defined(RTM_COMPILER_MSVC) && RTM_COMPILER_MSVC < RTM_COMPILER_MSVC_2019 && defined(RTM_ARCH_X86) && !defined(NDEBUG)
 				const uint32_t x_mask = x ? 0xFFFFFFFFU : 0;
 				const uint32_t y_mask = y ? 0xFFFFFFFFU : 0;
 				const uint32_t z_mask = z ? 0xFFFFFFFFU : 0;
@@ -224,12 +224,12 @@ namespace rtm
 #if defined(RTM_SSE2_INTRINSICS)
 	//////////////////////////////////////////////////////////////////////////
 	// HACK ALERT!
-	// VS2015, VS2017, and VS2019 crash when compiling with _mm_set_epi64x() here.
+	// VS2015 and VS2017 crash when compiling with _mm_set_epi64x() here.
 	// To work around this, we use alternative code. We assume that the high and low words
 	// are identical in the mask, which should be true.
 	// See: https://github.com/nfrechette/rtm/issues/84
 	//////////////////////////////////////////////////////////////////////////
-	#if defined(RTM_COMPILER_MSVC) && defined(RTM_ARCH_X86) && !defined(NDEBUG)
+	#if defined(RTM_COMPILER_MSVC) && RTM_COMPILER_MSVC < RTM_COMPILER_MSVC_2019 && defined(RTM_ARCH_X86) && !defined(NDEBUG)
 				const uint32_t x_mask = x ? 0xFFFFFFFFU : 0;
 				const uint32_t y_mask = y ? 0xFFFFFFFFU : 0;
 				const uint32_t z_mask = z ? 0xFFFFFFFFU : 0;


### PR DESCRIPTION
Fixes #84