### PR TITLE
fix: std::numeric_limits::max() in memory_utils.h conflicted with minwindef.h

### DIFF
--- a/includes/rtm/impl/memory_utils.h
+++ b/includes/rtm/impl/memory_utils.h
@@ -205,7 +205,7 @@ namespace rtm
 				else if (static_condition<std::is_signed<SrcRealType>::value>::test())
 					return int64_t(input) >= 0 && SrcType(DstType(input)) == input;
 				else
-					return uint64_t(input) <= uint64_t(std::numeric_limits<DstType>::max());
+					return uint64_t(input) <= uint64_t((std::numeric_limits<DstType>::max)());
 			};
 		};
 


### PR DESCRIPTION
fix: usage of std::numeric_limits<DstType>::max() in memory_utils.h conflicted with minwindef.h under some circumstances

Hi, 
I use rtm in my personal project. Somehow I include the "minwindef.h" file (actually I don't know where it's included, maybe it's included by some third-party library I am using) and when I build project on Windows, an error happen:
```
0>memory_utils.h(208): Warning C4003 : 类函数宏的调用“max”参数不足 // means that number of parameters not correct when calling macro max
0>memory_utils.h(208): Error C1075 fatal: “{”: 未找到匹配令牌
```
Line 208:
`return uint64_t(input) <= uint64_t((std::numeric_limits<DstType>::max());` 
I jump to source code of max and it turns out to be in minwindef.h:
```
#ifndef max
#define max(a,b)            (((a) > (b)) ? (a) : (b))
#endif
```

With google it's easy to find out solution: https://stackoverflow.com/questions/1394132/macro-and-member-function-conflict.

It's a tricky and potential build error only happens in specific situation. I try to fix it in this PR, and maybe there's a better way?