### PR TITLE
fix(tools): reduce natvis match priority for built-in types

### DIFF
--- a/tools/vs_visualizers/rtm.natvis
+++ b/tools/vs_visualizers/rtm.natvis
@@ -10,15 +10,15 @@
 		<DisplayString>({x}, {y}, {z}, {w})</DisplayString>
 	</Type>
 
-	<Type Name="__m128">
+	<Type Name="__m128" Priority="Low">
 		<DisplayString>({m128_f32[0]}, {m128_f32[1]}, {m128_f32[2]}, {m128_f32[3]})</DisplayString>
 	</Type>
 
-	<Type Name="__m128i">
+	<Type Name="__m128i" Priority="Low">
 		<DisplayString>({m128i_u32[0]}, {m128i_u32[1]}, {m128i_u32[2]}, {m128i_u32[3]})</DisplayString>
 	</Type>
 
-	<Type Name="__m128d">
+	<Type Name="__m128d" Priority="Low">
 		<DisplayString>({m128d_f64[0]}, {m128d_f64[1]})</DisplayString>
 	</Type>
 


### PR DESCRIPTION
RTM is generally integrated into environments with other math libraries for example, Unreal Engine. Host runtimes often already have natvis for built-in intrinsic types. To avoid conflicts, we lower the RTM priority to let whatever formatting the host runtime chooses (if any).